### PR TITLE
Store chromecast_devices as proper objects in attributes

### DIFF
--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/fondberg/spotcast",
   "requirements": [
     "fondberg-spotipy==2.4.5-dev2",
-    "pychromecast==3.2.2",
+    "pychromecast==4.0.1",
     "spotify_token==0.1.0"
   ],
   "dependencies": [

--- a/custom_components/spotcast/sensor.py
+++ b/custom_components/spotcast/sensor.py
@@ -54,7 +54,7 @@ class ChromecastDevicesSensor(Entity):
                 'manufacturer': cast.device.manufacturer
             }
             chromecasts.append(device)
-        self._attributes['devices_json'] = json.dumps(chromecasts, ensure_ascii=False)
+        self._attributes['devices_json'] = chromecasts
         # self._attributes['devices'] = chromecasts
         self._attributes['last_update'] = dt.now().isoformat('T')
         self._state = STATE_OK

--- a/custom_components/spotcast/sensor.py
+++ b/custom_components/spotcast/sensor.py
@@ -54,8 +54,8 @@ class ChromecastDevicesSensor(Entity):
                 'manufacturer': cast.device.manufacturer
             }
             chromecasts.append(device)
-        self._attributes['devices_json'] = chromecasts
-        # self._attributes['devices'] = chromecasts
+        self._attributes['devices_json'] = json.dumps(chromecasts, ensure_ascii=False)
+        self._attributes['devices'] = chromecasts
         self._attributes['last_update'] = dt.now().isoformat('T')
         self._state = STATE_OK
 


### PR DESCRIPTION
Storing this data as a string makes it impossible to use it in templates, in other words useless in my use case - where I want to use this data to populate an input_select;
```jinja
{{ states.sensor.chromecast_devices.attributes.devices_json | map(attribute='name') | list }}
```