### PR TITLE
Changed transfer playback option to force playback even if nothing is currently playing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,16 @@ Used by https://github.com/custom-cards/spotify-card.
 Community post: https://community.home-assistant.io/t/spotcast-custom-component-to-start-playback-on-an-idle-chromecast-device/114232
 
 ***Important***
+
 Release 2.7.0 requires home-assistant >= 0.105.0
+
 Release 2.8.0 now supports Spotify connect devices (thanks to @kleinc80). And no, Sonos would still require extra integration, send one to me and I'll integrate it.
+
+Release 2.9.0 now supports possibility to "Transfer Playback" even when there is nothing currently playing
+
+***Required configuration change with release 2.9.0***
+
+The parameter transfer_playback does not exist anymore and if you use it, you need to update your configuration. Use and empty uri and optionally the new parameter force_playback instead.
 
 ## Installation
 
@@ -75,23 +83,22 @@ optionally you can specify the `entity_id` of an existing home assistant chromec
 ```
 
 ### transfer current playback for the account
-Omitting `uri` will check if something is playing on any of the accounts devices and transfer the playback to the specified device.
+Omitting `uri` will transfer the playback to the specified device.
 ```
 {
 	"device_name" : "Högtalare uppe"
 }
 ```
-or use the parameter `transfer_playback` which will only transfer if something is playing otherwise use the specified `uri`.
+Use the parameter `force_playback` to continue the user's playback even if nothing is currently playing.
 ```
 {
 	"device_name" : "MultiRoom",
-	"uri" : "spotify:playlist:37i9dQZF1DX3yvAYDslnv8",
-	"transfer_playback" : true
+	"force_playback" : true
 }
 ```
 where
  - `device_name` is the friendly name of the Chromecast
- - `transfer_playback` (optional) true or false, continue ongoing playback on your Chromecast
+ - `force_playback` (optional) true or false, true to continue the user's playback even if nothing is currently playing
 
 
 #### start playback on a device with non default account

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Release 2.9.0 now supports possibility to "Transfer Playback" even when there is
 
 ***Required configuration change with release 2.9.0***
 
-The parameter transfer_playback does not exist anymore and if you use it, you need to update your configuration. Use and empty uri and optionally the new parameter force_playback instead.
+The parameter transfer_playback does not exist anymore and if you use it, you need to update your configuration. Use an empty uri and optionally the new parameter force_playback instead.
 
 ## Installation
 

--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -163,6 +163,7 @@ async def async_setup(hass, config):
         shuffle = call.data.get(CONF_SHUFFLE)
         spotify_device_id = call.data.get(CONF_SPOTIFY_DEVICE_ID)
         position = call.data.get(CONF_OFFSET)
+        transfer_playback = call.data.get(CONF_TRANSFER_PLAYBACK)
 
         # Account
         user, pwd = get_account_credentials(call)
@@ -183,11 +184,10 @@ async def async_setup(hass, config):
             spotify_cast_device.startSpotifyController(access_token, expires)
             spotify_device_id = spotify_cast_device.getSpotifyDeviceId(client)
 
-        transfer_playback = shouldTransferPlayback(call, client)
-        if transfer_playback == True:
+        if shouldTransferPlayback(call, client) == True:
             _LOGGER.debug('Transfering playback')
             current_playback = client.current_playback()
-            if current_playback is not None:
+            if current_playback is not None or transfer_playback == True:
                 _LOGGER.debug('current_playback from spotipy: %s', current_playback)
                 client.transfer_playback(device_id=spotify_device_id, force_play=True)
             else:

--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.components.cast.media_player import KNOWN_CHROMECAST_INFO_KEY
 import random
 import time
 
-_VERSION = '2.8.0'
+_VERSION = '2.9.0'
 DOMAIN = 'spotcast'
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/spotcast/services.yaml
+++ b/custom_components/spotcast/services.yaml
@@ -16,7 +16,7 @@ start:
     account:
       description: "Optionally starts Spotify using an alternative account specified in config."
       example: "my_wifes"
-    transfer_playback:
+    force_playback:
       description: "Transfer playback if something is playing on the account otherwise play specified URI."
       example: true
     random_song:

--- a/custom_components/spotcast/services.yaml
+++ b/custom_components/spotcast/services.yaml
@@ -11,13 +11,13 @@ start:
       description: "The entity_id of the chromecast mediaplayer (not used together with device_name and spotify_device_name)."
       example:  "media_player.vardagsrum"
     uri:
-      description: "Supported Spotify URI as string (if omitted will try to transfer current playback)."
+      description: "Supported Spotify URI as string. None or empty uri will transfer the current/last playback (see parameter force_playback)."
       example: "spotify:playlist:37i9dQZF1DX3yvAYDslnv8"
     account:
       description: "Optionally starts Spotify using an alternative account specified in config."
       example: "my_wifes"
     force_playback:
-      description: "Transfer playback if something is playing on the account otherwise play specified URI."
+      description: "In case of transfering playback: If true starts playing the user's last playback even if nothing is currently playing. Default: false"
       example: true
     random_song:
       description: "Starts the playback at a random position in the playlist or album."

--- a/info.md
+++ b/info.md
@@ -10,9 +10,9 @@ Becasue starting playback using the API requires more powerful token the usernam
 
 Used by https://github.com/custom-cards/spotify-card.
 
-***Required configuration change with release 2.9.0***
+***Required configuration change with release 2.9.0:***
 
-The parameter transfer_playback does not exist anymore and if you use it, you need to update your configuration. Use and empty uri and optionally the new parameter force_playback instead.
+***The parameter transfer_playback does not exist anymore and if you use it, you need to update your configuration. Use an empty uri and optionally the new parameter force_playback instead.***
 
 # Minimal Configuration
 #### Single account

--- a/info.md
+++ b/info.md
@@ -10,6 +10,10 @@ Becasue starting playback using the API requires more powerful token the usernam
 
 Used by https://github.com/custom-cards/spotify-card.
 
+***Required configuration change with release 2.9.0***
+
+The parameter transfer_playback does not exist anymore and if you use it, you need to update your configuration. Use and empty uri and optionally the new parameter force_playback instead.
+
 # Minimal Configuration
 #### Single account
 Add the following to your config


### PR DESCRIPTION
My suggestion for #14. What do you think?

It implies a slight change in behaviour:
- Call "start" with emtpy uri -> transfer playback but do not play.
- Call start with empty uri and transfer_play=true -> transfer playback and continue playing