### PR TITLE
Bump pychromecast

### DIFF
--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/fondberg/spotcast",
   "requirements": [
     "spotipy==2.10.0",
-    "pychromecast==4.1.1",
+    "pychromecast==4.2.0",
     "spotify_token==0.1.2"
   ],
   "homeassistant": "0.108.3",


### PR DESCRIPTION
I noticed on restarts HA was installing this version while spotcast is installing 4.1.1 causing the restart to take a long time. Also I noticed the next version of HA 0.109.0 has bumped their spotipy to 4.11.1 so when the time comes I can submit another PR.