### PR TITLE
Bump dependencies

### DIFF
--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/fondberg/spotcast",
   "requirements": [
     "spotipy==2.11.1",
-    "pychromecast==4.2.0",
+    "pychromecast==5.0.0",
     "spotify_token==0.1.2"
   ],
   "homeassistant": "0.109.0",

--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -3,11 +3,11 @@
   "name": "Start Spotify on chromecast",
   "documentation": "https://github.com/fondberg/spotcast",
   "requirements": [
-    "spotipy==2.10.0",
-    "pychromecast==4.1.1",
+    "spotipy==2.11.1",
+    "pychromecast==4.2.0",
     "spotify_token==0.1.2"
   ],
-  "homeassistant": "0.108.3",
+  "homeassistant": "0.109.0",
   "dependencies": [
   ],
   "codeowners": [


### PR DESCRIPTION
HA 0.109.0 is moving to spotipy 2.11.1 this is a dependency bump to match HA. pychromecast was bumped back in March.