### PR TITLE
Allow changes to be tested on beta HA

### DIFF
--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -7,7 +7,7 @@
     "pychromecast==5.0.0",
     "spotify_token==0.1.2"
   ],
-  "homeassistant": "0.109.0",
+  "homeassistant": "0.109.0b1",
   "dependencies": [
   ],
   "codeowners": [


### PR DESCRIPTION
When requirements are set to 0.109.0 for HA you cannot test on beta versions this change should allow HACS to install this component in the beta version of HA.