### PR TITLE
fix(README.md): Closed code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ spotcast:
 	"uri" : "spotify:playlist:37i9dQZF1DX3yvAYDslnv8",
 	"random_song": true
 }
-
+```
 #### start playback on a device with default account
 ```
 {


### PR DESCRIPTION
A code block under header `### start playback on spotify connect device` wasn't closed, resulting in everything following that being misformatted.