### PR TITLE
Fix inconsistent speaker groups

### DIFF
--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -423,32 +423,19 @@ class SpotifyCastDevice:
                 None,
             )
 
-        _LOGGER.info("cast info: %s", cast_info)
+        _LOGGER.debug("cast info: %s", cast_info)
 
         if cast_info:
-            if cast_info.model_name == "Google Cast Group":
-                chromecasts, browser  = pychromecast.get_listed_chromecasts(friendly_names=[cast_info.friendly_name], zeroconf_instance=ChromeCastZeroconf.get_zeroconf())
-                cast = None
-                for _cast in chromecasts:
-                   _LOGGER.info("_cast {}".format(_cast))
-                   if _cast.device.friendly_name == cast_info.friendly_name:
-                      cast = _cast
-                      break
-                pychromecast.stop_discovery(browser)
-                if not cast:
-                   _LOGGER.info('No chromecast with uuuid "{}" discovered'.format(cast_info.uuid))
-                else:
-                   _LOGGER.info("cast {}".format(cast))
-                   return cast
-            return pychromecast._get_chromecast_from_host(
-                (
-                    cast_info.host,
-                    cast_info.port,
-                    cast_info.uuid,
-                    cast_info.model_name,
-                    cast_info.friendly_name,
-                )
-            )
+            return pychromecast.get_chromecast_from_service(
+                  (
+                     cast_info.services,
+                     cast_info.uuid,
+                     cast_info.model_name,
+                     cast_info.friendly_name,
+                     None,
+                     None,
+                 ),
+                 ChromeCastZeroconf.get_zeroconf()) 
         _LOGGER.error(
             "Could not find device %s from hass.data",
             device_name,


### PR DESCRIPTION
I've been getting this error when casting to speaker groups

```
2020-08-17 11:46:30 ERROR (Thread-225) [pychromecast.socket_client] [(192.168.86.59):32023] Failed to connect, retrying in 5.0s
 ````

This is caused by using the host to retrieve chromecast - and in speaker group the host changes according to which device is elected leader.

This change uses UUID to retreive the chromecast, which should have up to date leader / host details.

It's been working well for me.  If we run into issues we can do alternative implementations (in my first commit since overrwritten) and make a discrete discovery for that UUID which would be the most robust way at the cost of additional discovery overhead. 