### PR TITLE
Set `after_dependencies` on cast and spotify integrations

### DIFF
--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -8,6 +8,9 @@
   "homeassistant": "0.113.0",
   "dependencies": [
   ],
+  "after_dependencies": [
+     "cast"
+  ],
   "codeowners": [
     "@fondberg"
   ]

--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -9,7 +9,7 @@
   "dependencies": [
   ],
   "after_dependencies": [
-     "cast"
+    "cast"
   ],
   "codeowners": [
     "@fondberg"

--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -9,7 +9,8 @@
   "dependencies": [
   ],
   "after_dependencies": [
-    "cast"
+    "cast",
+    "spotify"
   ],
   "codeowners": [
     "@fondberg"


### PR DESCRIPTION
This will load cast and all of it's dependencies before spotcast preventing CI errors and avoiding problems by pinning versions of dependencies in spotcast itself.

Fixes #136.