### PR TITLE
FIX error resulting from unknown spotify devices

### DIFF
--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -561,16 +561,17 @@ class SpotifyCastDevice:
             "devices_available: %s %s", devices_available, self.spotifyController.device
         )
 
-        for device in devices_available["devices"]:
-            if device["id"] == self.spotifyController.device:
-                return device["id"]
+        if devices := devices_available["devices"]:
+            for device in devices:
+                if device["id"] == self.spotifyController.device:
+                    return device["id"]
 
         _LOGGER.error(
             'No device with id "{}" known by Spotify'.format(
                 self.spotifyController.device
             )
         )
-        _LOGGER.error("Known devices: {}".format(devices_available["devices"]))
+        _LOGGER.error("Known devices: {}".format(devices))
 
         # Default to try to use the one we got
         return self.spotifyController.device


### PR DESCRIPTION
related #170 

I am still having problems getting the device list from spotify for which I propose a simple fix.
In my case `devices_available["devices"] is None`, which leads to a `NoneType`-Error while trying to iterate over it.

log output without this PR:
```
2021-04-12 18:13:35 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [1866674008] Error handling message: Unknown error
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/decorators.py", line 18, in _handle_async_response
    await func(hass, connection, msg)
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/commands.py", line 439, in handle_execute_script
    await script_obj.async_run(context=context)
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 1195, in async_run
    await asyncio.shield(run.async_run())
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 341, in async_run
    await self._async_step(log_exceptions=False)
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 359, in _async_step
    await getattr(self, handler)()
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 559, in _async_call_service_step
    await service_task
  File "/usr/src/homeassistant/homeassistant/core.py", line 1480, in async_call
    task.result()
  File "/usr/src/homeassistant/homeassistant/core.py", line 1519, in _execute_service
    await self._hass.async_add_executor_job(handler.job.target, service_call)
  File "/usr/local/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/config/custom_components/spotcast/__init__.py", line 388, in start_casting
    spotify_device_id = spotify_cast_device.getSpotifyDeviceId(client)
  File "/config/custom_components/spotcast/__init__.py", line 575, in getSpotifyDeviceId
    for device in devices_available["devices"]:
TypeError: 'NoneType' object is not iterable
```