### PR TITLE
Update manifest.json to list spotify as dependency 

### DIFF
--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -2,16 +2,17 @@
   "domain": "spotcast",
   "name": "Start Spotify on chromecast",
   "documentation": "https://github.com/fondberg/spotcast",
+  "issue_tracker": "https://github.com/fondberg/spotcast/issues",
   "requirements": [
     "spotify_token==1.0.0"
   ],
   "homeassistant": "2021.4.1",
   "version": "3.5.2",
   "dependencies": [
+    "spotify"
   ],
   "after_dependencies": [
-    "cast",
-    "spotify"
+    "cast"
   ],
   "codeowners": [
     "@fondberg"


### PR DESCRIPTION
I've updated the manifest.json file to include the HA `spotify` integration as a hard dependency for `spotcast`.

While I was at it, I've also included the link to the issue tracker for use in the info pane of HA.