### PR TITLE
Set optional parameters to 'required: false'

### DIFF
--- a/custom_components/spotcast/services.yaml
+++ b/custom_components/spotcast/services.yaml
@@ -42,7 +42,7 @@ start:
       name: "Force Playback"
       description: "In case of transfering playback: If true starts playing the user's last playback even if nothing is currently playing."
       example: true
-      required: true
+      required: false
       default: false
       selector:
         boolean:
@@ -50,7 +50,7 @@ start:
       name: "Random Song"
       description: "Starts the playback at a random position in the playlist or album."
       example: true
-      required: true
+      required: false
       default: false
       selector:
         boolean:
@@ -58,7 +58,7 @@ start:
       name: "Repeat"
       description: "Set repeat mode for playback."
       example: "track"
-      required: true
+      required: false
       default: "off"
       selector:
         select:
@@ -78,7 +78,7 @@ start:
       name: "Offset"
       description: "Set offset mode for playback. 0 is the first song."
       example: 1
-      required: true
+      required: false
       default: 0
       selector:
         number:


### PR DESCRIPTION
Setting the following optional parameters to 'required: false' in services.yaml, to allow for not specifying them in service calls in the HA developer tools:

- Force playback
- Random 
- Repeat
- Offset

These optional values are not required and shouldn't be flagged as such.

Fixes #197 
Introduced by #180 