### PR TITLE
Use get_spotify_devices in getSpotifyConnectDeviceId

### DIFF
--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -357,7 +357,7 @@ def setup(hass, config):
             client.start_playback(**kwargs)
 
     def getSpotifyConnectDeviceId(client, device_name):
-        devices_available = client.devices()
+        devices_available = get_spotify_devices(hass, client._get("me")["id"])
         for device in devices_available["devices"]:
             if device["name"] == device_name:
                 return device["id"]


### PR DESCRIPTION
Using client.devices() was not returning any devices. Using the get_spotify_devices method instead seems to work. 

On my configuration, this solves 'Could not find device with name..' issue I had with connecting to a Yamaha Musiccast. 

Might be related to #70 

