### PR TITLE
Add hacs.json to capture minimum HA version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Copy all files from custom_components/spotcast/ to custom_components/spotcast/ i
 
 ## Configuration
 
+### Minimum Home Assistant version
+
+Spotcast is compatible with any version since 2021.4.1.
+
 ### Official Spotify Integration
 
 Note that as of v3.5.2 you must also have the official [Home Assistant Spotify Integration](https://www.home-assistant.io/integrations/spotify/) installed and configured for this custom component to work. This is because it provides the correct device list which has the correct scopes in its token.

--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "spotcast",
-  "name": "Start Spotify on chromecast",
+  "name": "Spotcast",
   "documentation": "https://github.com/fondberg/spotcast",
   "issue_tracker": "https://github.com/fondberg/spotcast/issues",
   "iot_class": "cloud_polling",

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,6 @@
+{
+  "name": "Spotcast",
+  "domains": ["media_player", "sensor"],
+  "homeassistant": "2021.4.1",
+  "iot_class": ["Cloud Polling"]
+}

--- a/info.md
+++ b/info.md
@@ -10,6 +10,10 @@ Because starting playback using the API requires more powerful token the usernam
 
 Used by https://github.com/custom-cards/spotify-card.
 
+# Minimum Home Assistant version
+
+Spotcast is compatible with any version since 2021.4.1.
+
 # Minimal Configuration
 Note that since v3.5.2 you must also have the official [Home Assistant Spotify Integration](https://www.home-assistant.io/integrations/spotify/) installed and configured for this custom component to work. This is because it provides the correct device list which has the correct scopes in its token.
 

--- a/info.md
+++ b/info.md
@@ -10,14 +10,17 @@ Because starting playback using the API requires more powerful token the usernam
 
 Used by https://github.com/custom-cards/spotify-card.
 
-# Minimum Home Assistant version
+# Minimal Configuration
+
+## Minimum Home Assistant version
 
 Spotcast is compatible with any version since 2021.4.1.
 
-# Minimal Configuration
+## Official Spotify integration
+
 Note that since v3.5.2 you must also have the official [Home Assistant Spotify Integration](https://www.home-assistant.io/integrations/spotify/) installed and configured for this custom component to work. This is because it provides the correct device list which has the correct scopes in its token.
 
-### Single account
+## Single account
 Add the following to your config
 ```yaml
 spotcast:


### PR DESCRIPTION
Add hacs.json file to have HACS prevent users installing latest Spotcast on non-compatible HA versions. Also changed manifest.json to keep naming convention, and updated readme.md and info.md to capture min HA version.

hacs.json description: https://hacs.xyz/docs/publish/start/#hacsjson

Does not need a new release, change will be picked up automatically when merged or can wait until next release.

Fixes #230 
