### PR TITLE
Add name to ignore_fully_played option

### DIFF
--- a/custom_components/spotcast/services.yaml
+++ b/custom_components/spotcast/services.yaml
@@ -97,8 +97,8 @@ start:
           step: 1
           min: 0
           max: 100
-
     ignore_fully_played:
+      name: "Ignore Fully Played"
       description: "Set to ignore or not already played episodes in a podcast playlist"
       example: true
       required: false


### PR DESCRIPTION
I noticed that this parameter doesn't have a readable name in the service call UI, so this seemed like a most straightforward fix.