### PR TITLE
added functionality - search Spotify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-__VERSION__ = "3.6.16"
+__VERSION__ = "3.6.17"
 
 bump:
 	bump2version --allow-dirty --current-version $(__VERSION__) patch Makefile custom_components/spotcast/manifest.json

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ where:
 * `spotify_device_id` is the device ID of the Spotify Connect device 
 * `device_name` is the friendly name of the chromecast device
 * `uri` is the Spotify uri, supports all uris including track (limit to one track)
+* `search` is a search query to resolve into a uri. This parameter will be overlooked if a uri is provided
 * `random_song` optional parameter that starts the playback at a random position in the playlist
 * `repeat` optional parameter that repeats the playlist/track
 * `shuffle` optional parameter to set shuffle mode for playback
@@ -161,6 +162,17 @@ To use the Spotcast service with a Spotify Connect device, you need the `spotify
       start_volume: 50
       entity_id: media_player.gh_kok
     service: spotcast.start
+```
+
+```yaml
+- service: spotcast.start
+  data:
+    search: "Brown Bird"
+    # resolve to spotify:artist:5zzbSFZMVpvxSlWAkqqtHP at the time of writing
+    random_song: true
+    shuffle: true
+    start_volume: 50
+    entity_id: media_player.cuisine
 ```
 
 ### Transfer current playback for the account

--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -17,6 +17,7 @@ from .const import (
     CONF_SPOTIFY_ACCOUNT,
     CONF_SPOTIFY_DEVICE_ID,
     CONF_SPOTIFY_URI,
+    CONF_SPOTIFY_SEARCH,
     CONF_START_VOL,
     DOMAIN,
     SCHEMA_PLAYLISTS,
@@ -128,6 +129,7 @@ def setup(hass, config):
     def start_casting(call):
         """service called."""
         uri = call.data.get(CONF_SPOTIFY_URI)
+        search = call.data.get(CONF_SPOTIFY_SEARCH)
         random_song = call.data.get(CONF_RANDOM, False)
         repeat = call.data.get(CONF_REPEAT, False)
         shuffle = call.data.get(CONF_SHUFFLE, False)
@@ -148,7 +150,7 @@ def setup(hass, config):
                 account, spotify_device_id, device_name, entity_id
             )
 
-        if uri is None or uri.strip() == "":
+        if (uri is None or uri.strip() == "") and (search is None or search.strip() == ""):
             _LOGGER.debug("Transfering playback")
             current_playback = client.current_playback()
             if current_playback is not None:
@@ -159,6 +161,11 @@ def setup(hass, config):
                 device_id=spotify_device_id, force_play=force_playback
             )
         else:
+
+            if uri is None or uri.strip() == "":
+                # get uri from search request
+                uri = helpers.get_uri_from_search(search, account)
+
             spotcast_controller.play(
                 client,
                 spotify_device_id,

--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -164,7 +164,8 @@ def setup(hass, config):
 
             if uri is None or uri.strip() == "":
                 # get uri from search request
-                uri = helpers.get_uri_from_search(search, account)
+                token, expires = spotcast_controller.get_token_instance(account).get_spotify_token()
+                uri = helpers.get_uri_from_search(search, token)
 
             spotcast_controller.play(
                 client,

--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -164,8 +164,7 @@ def setup(hass, config):
 
             if uri is None or uri.strip() == "":
                 # get uri from search request
-                token, expires = spotcast_controller.get_token_instance(account).get_spotify_token()
-                uri = helpers.get_uri_from_search(search, token)
+                uri = helpers.get_uri_from_search(search, client)
 
             spotcast_controller.play(
                 client,

--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -164,7 +164,7 @@ def setup(hass, config):
 
             if uri is None or uri.strip() == "":
                 # get uri from search request
-                uri = helpers.get_uri_from_search(search, client)
+                uri = helpers.get_search_results(search, client)
 
             spotcast_controller.play(
                 client,

--- a/custom_components/spotcast/const.py
+++ b/custom_components/spotcast/const.py
@@ -10,6 +10,7 @@ DOMAIN = "spotcast"
 CONF_SPOTIFY_DEVICE_ID = "spotify_device_id"
 CONF_DEVICE_NAME = "device_name"
 CONF_SPOTIFY_URI = "uri"
+CONF_SPOTIFY_SEARCH
 CONF_ACCOUNTS = "accounts"
 CONF_SPOTIFY_ACCOUNT = "account"
 CONF_FORCE_PLAYBACK = "force_playback"
@@ -69,6 +70,7 @@ SERVICE_START_COMMAND_SCHEMA = vol.Schema(
         vol.Optional(CONF_SPOTIFY_DEVICE_ID): cv.string,
         vol.Optional(CONF_ENTITY_ID): cv.string,
         vol.Optional(CONF_SPOTIFY_URI): cv.string,
+        vol.Optional(CONF_SPOTIFY_SEARCH): cv.string,
         vol.Optional(CONF_SPOTIFY_ACCOUNT): cv.string,
         vol.Optional(CONF_FORCE_PLAYBACK, default=False): cv.boolean,
         vol.Optional(CONF_RANDOM, default=False): cv.boolean,

--- a/custom_components/spotcast/const.py
+++ b/custom_components/spotcast/const.py
@@ -10,7 +10,7 @@ DOMAIN = "spotcast"
 CONF_SPOTIFY_DEVICE_ID = "spotify_device_id"
 CONF_DEVICE_NAME = "device_name"
 CONF_SPOTIFY_URI = "uri"
-CONF_SPOTIFY_SEARCH
+CONF_SPOTIFY_SEARCH = "search"
 CONF_ACCOUNTS = "accounts"
 CONF_SPOTIFY_ACCOUNT = "account"
 CONF_FORCE_PLAYBACK = "force_playback"

--- a/custom_components/spotcast/helpers.py
+++ b/custom_components/spotcast/helpers.py
@@ -64,42 +64,32 @@ def async_wrap(func):
 
     return run
 
-def get_uri_from_search(search, token):
-
-    results = __get_search_results(search, token)
-
-    return results[0]['name']
-
-def __get_search_results(search, token):
-    BASE_URL = "https://api.spotify.com/v1/search?q="
+def get_search_results(search, spotify_client):
+    
     SEARCH_TYPES = ["artist", "album", "track", "playlist"]
 
     search = search.upper()
 
-    headers = {
-        'Authorization': 'Bearer {token}'.format(token=token)
-    }
-
     results = []
 
     for searchType in SEARCH_TYPES:
-        
-        try:
-            result = requests.get(
-                BASE_URL +
-                searchType + "%3A" + urllib.parse.quote(search, safe='') +
-                "&type=" + searchType +
-                "&limit=1",
-                headers=headers).json()[searchType + 's']['items'][0]
 
-        
+        try:
+    
+            result = spotify_client.search(
+                searchType + ":" + urllib.parse.quote(search, safe=''),
+                limit=1,
+                offset=0,
+                type=searchType)[searchType + 's']['items'][0]
+
             results.append(
                 {
-                    'name':result['name'].upper(),
+                    'name': result['name'].upper(),
                     'uri': result['uri']
                 }
             )
+
         except IndexError:
             pass
 
-    return sorted(results, key=lambda x: difflib.SequenceMatcher(None, x['name'], search).ratio(), reverse=True)
+    return sorted(results, key=lambda x: difflib.SequenceMatcher(None, x['name'], search).ratio(), reverse=True)[0]['uri']

--- a/custom_components/spotcast/helpers.py
+++ b/custom_components/spotcast/helpers.py
@@ -77,7 +77,7 @@ def get_search_results(search, spotify_client):
         try:
     
             result = spotify_client.search(
-                searchType + ":" + urllib.parse.quote(search, safe=''),
+                searchType + ":" + search,
                 limit=1,
                 offset=0,
                 type=searchType)[searchType + 's']['items'][0]

--- a/custom_components/spotcast/helpers.py
+++ b/custom_components/spotcast/helpers.py
@@ -98,6 +98,6 @@ def get_search_results(search, spotify_client):
 
     bestMatch = sorted(results, key=lambda x: difflib.SequenceMatcher(None, x['name'], search).ratio(), reverse=True)[0]
 
-    _LOGGER.debug("Best match for %s is %s", search. bestMatch['name'])
+    _LOGGER.debug("Best match for %s is %s", search, bestMatch['name'])
 
     return bestMatch['uri']

--- a/custom_components/spotcast/helpers.py
+++ b/custom_components/spotcast/helpers.py
@@ -65,6 +65,8 @@ def async_wrap(func):
     return run
 
 def get_search_results(search, spotify_client):
+
+    _LOGGER.debug("using search query to find uri")
     
     SEARCH_TYPES = ["artist", "album", "track", "playlist"]
 
@@ -89,7 +91,13 @@ def get_search_results(search, spotify_client):
                 }
             )
 
+            _LOGGER.debug("search result for %s: %s", searchType, result['name'])
+
         except IndexError:
             pass
 
-    return sorted(results, key=lambda x: difflib.SequenceMatcher(None, x['name'], search).ratio(), reverse=True)[0]['uri']
+    bestMatch = sorted(results, key=lambda x: difflib.SequenceMatcher(None, x['name'], search).ratio(), reverse=True)[0]
+
+    _LOGGER.debug("Best match for %s is %s", search. bestMatch['name'])
+
+    return bestMatch['uri']

--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -7,7 +7,7 @@
   "requirements": [
     "spotify_token==1.0.0"
   ],
-  "version": "v3.6.16",
+  "version": "v3.6.17",
   "dependencies": [
     "spotify"
   ],

--- a/custom_components/spotcast/services.yaml
+++ b/custom_components/spotcast/services.yaml
@@ -18,7 +18,7 @@ start:
     entity_id:
       name: "Entity ID"
       description: "The entity_id of the chromecast mediaplayer. Friendly name MUST match the spotify connect device name (not used together with device_name and spotify_device_id)."
-      example:  "media_player.vardagsrum"
+      example: "media_player.vardagsrum"
       required: false
       selector:
         entity:
@@ -28,6 +28,13 @@ start:
       name: "URI"
       description: "Supported Spotify URI as string. None or empty uri will transfer the current/last playback (see parameter force_playback)."
       example: "spotify:playlist:37i9dQZF1DX3yvAYDslnv8"
+      required: false
+      selector:
+        text:
+
+    search:
+      name: "Search"
+      description: "A Search request to the spotify API. Will play the most relevant search result."
       required: false
       selector:
         text:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.6.16
+current_version = 3.6.17
 
 [flake8]
 exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build


### PR DESCRIPTION
I've added a functionality to send a search query to the Spotify API to provide the most relevant result from the string provided. It works by providing the data field "search" ie:

```yaml
service: spotcast.start
data:
  entity_id: media_player.cuisine
  random_song: true
  shuffle: true
  search: between the buried and me
```

Currently the code will only do a search request if the Uri field is empty. The flow of the search is has followed:

0. Intercept if Uri is none or empty
1. Get the most relevant result from each searchType (artist, album, track, and playlist)
2. Sort the results according the most identical to the search query
3. Set the Uri to the one of the results in index zero of the list
4. Continue the usual flow of the component
...

In case multiple results are identical, the priority will be artist->album->track->playlist. Let's take the search exemple "Between the buried and me". We have a song called "between the buried and me" on an album of the same name from a band of the same name. The uri that is returned will be the one from the artist.