### PR TITLE
corr-258

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-__VERSION__ = "3.6.19"
+__VERSION__ = "3.6.20"
 
 bump:
 	bump2version --allow-dirty --current-version $(__VERSION__) patch Makefile custom_components/spotcast/manifest.json

--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -42,12 +42,11 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def setup(hass, config):
-    
+
     # get spotify core integration status
     if not helpers.get_spotify_install_status(hass):
-        _LOGGER.error("Spotify integration was not found, aborting setup...")
-        return False
-    
+        _LOGGER.error("Spotify integration was not found, please verify integration is functionnal. Could result in python error...")
+
     """Setup the Spotcast service."""
     conf = config[DOMAIN]
 

--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -46,6 +46,7 @@ def setup(hass, config):
     # get spotify core integration status
     if not helpers.get_spotify_install_status(hass):
         _LOGGER.error("Spotify integration was not found, please verify integration is functionnal. Could result in python error...")
+        return False
 
     """Setup the Spotcast service."""
     conf = config[DOMAIN]

--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -12,7 +12,8 @@
     "spotify"
   ],
   "after_dependencies": [
-    "cast"
+    "cast",
+    "spotify"
   ],
   "codeowners": [
     "@fondberg"

--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -7,7 +7,7 @@
   "requirements": [
     "spotify_token==1.0.0"
   ],
-  "version": "v3.6.19",
+  "version": "v3.6.20",
   "dependencies": [
     "spotify"
   ],

--- a/custom_components/spotcast/spotcast_controller.py
+++ b/custom_components/spotcast/spotcast_controller.py
@@ -276,10 +276,17 @@ class SpotcastController:
         resp = {}
 
         if playlist_type == "discover-weekly":
-            playlist_type = "made-for-x"
-        
-        if playlist_type == "user" or playlist_type == "default" or playlist_type == "":
-            resp = client.current_user_playlists(limit=limit)
+            resp = client._get(
+                "views/made-for-x",
+                content_limit=limit,
+                locale=locale,
+                platform="web",
+                types="album,playlist,artist,show,station",
+                limit=limit,
+                offset=0,
+            )
+            resp = resp.get("content")
+
         elif playlist_type == "featured":
             resp = client.featured_playlists(
                 locale=locale,
@@ -290,15 +297,6 @@ class SpotcastController:
             )
             resp = resp.get("playlists")
         else:
-            resp = client._get(
-                "views/" + playlist_type,
-                content_limit=limit,
-                locale=locale,
-                platform="web",
-                types="album,playlist,artist,show,station",
-                limit=limit,
-                offset=0,
-            )
-            resp = resp.get("content")
+            resp = client.current_user_playlists(limit=limit)
 
         return resp

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.6.19
+current_version = 3.6.20
 
 [flake8]
 exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build


### PR DESCRIPTION
potential fix for #258. Still in testing. Will maintain the PR in draft until further testing.

The potential solution is to add Spotify in the after_depencies section of the manifest to ensure Spotify integration is loaded before going further. This test would normally ensure that the official Spotify Integration had time to be initiated before starting the setup and doing the test.