### PR TITLE
Fixes for 2021.12.0

### DIFF
--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -124,9 +124,9 @@ def setup(hass, config):
         _LOGGER.debug("%s", known_devices)
         resp = [
             {
-                "uuid": cast_info.uuid,
-                "model_name": cast_info.model_name,
-                "friendly_name": cast_info.friendly_name,
+                "uuid": str(cast_info.cast_info.uuid),
+                "model_name": cast_info.cast_info.model_name,
+                "friendly_name": cast_info.cast_info.friendly_name,
             }
             for cast_info in known_devices
         ]

--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -7,7 +7,7 @@
   "requirements": [
     "spotify_token==1.0.0"
   ],
-  "version": "v3.6.21",
+  "version": "v3.6.22",
   "dependencies": [
     "spotify"
   ],

--- a/custom_components/spotcast/sensor.py
+++ b/custom_components/spotcast/sensor.py
@@ -38,7 +38,7 @@ class ChromecastDevicesSensor(SensorEntity):
         return self._state
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes."""
         return self._attributes
 
@@ -81,7 +81,7 @@ class ChromecastPlaylistSensor(SensorEntity):
         return self._state
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes."""
         return self._attributes
 

--- a/custom_components/spotcast/sensor.py
+++ b/custom_components/spotcast/sensor.py
@@ -50,12 +50,11 @@ class ChromecastDevicesSensor(SensorEntity):
 
         chromecasts = [
             {
-                "host": "deprecated",
-                "port": "deprecated",
-                "uuid": cast_info.uuid,
-                "model_name": cast_info.model_name,
-                "name": cast_info.friendly_name,
-                "manufacturer": cast_info.manufacturer,
+                "uuid": str(cast_info.cast_info.uuid),
+                "model_name": cast_info.cast_info.model_name,
+                "name": cast_info.cast_info.friendly_name,
+                "manufacturer": cast_info.cast_info.manufacturer,
+                "cast_type": cast_info.cast_info.cast_type,
             }
             for cast_info in known_devices
         ]

--- a/custom_components/spotcast/spotcast_controller.py
+++ b/custom_components/spotcast/spotcast_controller.py
@@ -68,7 +68,7 @@ class SpotifyCastDevice:
         _LOGGER.debug("cast info: %s", cast_info)
         if cast_info:
             return pychromecast.get_chromecast_from_cast_info(
-                cast_info, ChromeCastZeroconf.get_zeroconf()
+                cast_info.cast_info, ChromeCastZeroconf.get_zeroconf()
             )
         _LOGGER.error(
             "Could not find device %s from hass.data",

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Spotcast",
   "domains": ["media_player", "sensor"],
-  "homeassistant": "2021.4.1",
+  "homeassistant": "2021.12.0",
   "iot_class": ["Cloud Polling"]
 }


### PR DESCRIPTION
2021.12.0 has a bump of `pychromecast`, which changes the way you can retrieve Chromecast info. 

https://github.com/home-assistant/core/pull/59719
https://github.com/home-assistant/core/pull/60205

With the changes in this PR I fixed the issue locally. It should be tested by others too.
Also implemented a fix for a warning on `device_state_attributes` while I was at it anyways - this is just a rename to `extra_state_attributes`

Fixes #269 
Fixes https://github.com/fondberg/spotcast/issues/273
Fixes https://github.com/fondberg/spotcast/issues/274
Fixes https://github.com/custom-cards/spotify-card/issues/170