### PR TITLE
Add playlist random selection from category

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,13 @@ The spotcast custom component creates a service called 'spotcast.start' in Home 
 
 where:
 
-* `spotify_device_id` is the device ID of the Spotify Connect device 
+* `spotify_device_id` is the device ID of the Spotify Connect device
 * `device_name` is the friendly name of the chromecast device
 * `uri` is the Spotify uri, supports all uris including track (limit to one track)
 * `search` is a search query to resolve into a uri. This parameter will be overlooked if a uri is provided
+* `category` let spotify pick a random playlist inside a given [category](https://developer.spotify.com/console/get-browse-categories/)
+* `country` restrict country to use when looking for playlists inside a category
+* `limit` restrict number of playlists to return when looking in a category. Note that only a single playlist will be chosen randomly from them.
 * `random_song` optional parameter that starts the playback at a random position in the playlist
 * `repeat` optional parameter that repeats the playlist/track
 * `shuffle` optional parameter to set shuffle mode for playback
@@ -132,7 +135,7 @@ where:
 Optionally you can specify the `entity_id` of an existing Home Assistant chromecast media-player like:
 
 ```json
-{ 
+{
   "entity_id" : "media_player.vardagsrum",
   "uri" : "spotify:playlist:37i9dQZF1DX3yvAYDslnv8"
 }
@@ -322,7 +325,7 @@ const res = await this.props.hass.callWS({
 ```
 
 ## Enabling debug log
-In configuration.yaml for you HA add and attach those the relevant logs. 
+In configuration.yaml for you HA add and attach those the relevant logs.
 Be sure to disable it later as it is quite noisy.
 ```
 logger:

--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -18,6 +18,9 @@ from .const import (
     CONF_SPOTIFY_DEVICE_ID,
     CONF_SPOTIFY_URI,
     CONF_SPOTIFY_SEARCH,
+    CONF_SPOTIFY_CATEGORY,
+    CONF_SPOTIFY_COUNTRY,
+    CONF_SPOTIFY_LIMIT,
     CONF_START_VOL,
     DOMAIN,
     SCHEMA_PLAYLISTS,
@@ -136,6 +139,9 @@ def setup(hass, config):
     def start_casting(call):
         """service called."""
         uri = call.data.get(CONF_SPOTIFY_URI)
+        category = call.data.get(CONF_SPOTIFY_CATEGORY)
+        country = call.data.get(CONF_SPOTIFY_COUNTRY)
+        limit = call.data.get(CONF_SPOTIFY_LIMIT)
         search = call.data.get(CONF_SPOTIFY_SEARCH)
         random_song = call.data.get(CONF_RANDOM, False)
         repeat = call.data.get(CONF_REPEAT, False)
@@ -157,7 +163,7 @@ def setup(hass, config):
                 account, spotify_device_id, device_name, entity_id
             )
 
-        if (uri is None or uri.strip() == "") and (search is None or search.strip() == ""):
+        if (uri is None or uri.strip() == "") and (search is None or search.strip() == "") and (category is None or category.strip() == ""):
             _LOGGER.debug("Transfering playback")
             current_playback = client.current_playback()
             if current_playback is not None:
@@ -166,6 +172,17 @@ def setup(hass, config):
             _LOGGER.debug("Force playback: %s", force_playback)
             client.transfer_playback(
                 device_id=spotify_device_id, force_play=force_playback
+            )
+        elif category:
+            uri = helpers.get_random_playlist_from_category(client, category, country, limit)
+
+            spotcast_controller.play(
+                client,
+                spotify_device_id,
+                uri,
+                random_song,
+                position,
+                ignore_fully_played,
             )
         else:
 

--- a/custom_components/spotcast/const.py
+++ b/custom_components/spotcast/const.py
@@ -11,6 +11,9 @@ CONF_SPOTIFY_DEVICE_ID = "spotify_device_id"
 CONF_DEVICE_NAME = "device_name"
 CONF_SPOTIFY_URI = "uri"
 CONF_SPOTIFY_SEARCH = "search"
+CONF_SPOTIFY_CATEGORY = "category"
+CONF_SPOTIFY_COUNTRY = "country"
+CONF_SPOTIFY_LIMIT = "limit"
 CONF_ACCOUNTS = "accounts"
 CONF_SPOTIFY_ACCOUNT = "account"
 CONF_FORCE_PLAYBACK = "force_playback"
@@ -71,6 +74,9 @@ SERVICE_START_COMMAND_SCHEMA = vol.Schema(
         vol.Optional(CONF_ENTITY_ID): cv.string,
         vol.Optional(CONF_SPOTIFY_URI): cv.string,
         vol.Optional(CONF_SPOTIFY_SEARCH): cv.string,
+        vol.Optional(CONF_SPOTIFY_CATEGORY): cv.string,
+        vol.Optional(CONF_SPOTIFY_COUNTRY): cv.string,
+        vol.Optional(CONF_SPOTIFY_LIMIT, default=20): cv.positive_int,
         vol.Optional(CONF_SPOTIFY_ACCOUNT): cv.string,
         vol.Optional(CONF_FORCE_PLAYBACK, default=False): cv.boolean,
         vol.Optional(CONF_RANDOM, default=False): cv.boolean,

--- a/custom_components/spotcast/helpers.py
+++ b/custom_components/spotcast/helpers.py
@@ -120,7 +120,7 @@ def get_random_playlist_from_category(spotify_client, category, country=None, li
     _LOGGER.debug(f"Get random playlist among {limit} playlists from category {category} in country {country}")
     playlists = spotify_client.category_playlists(category_id=category, country=country, limit=limit)["playlists"]["items"]
     chosen = random.choice(playlists)
-    _LOGGER.debug(f"Choosed playlist {chosen['name']} ({chosen['uri']}) from category {category}.")
+    _LOGGER.debug(f"Chose playlist {chosen['name']} ({chosen['uri']}) from category {category}.")
 
     return chosen['uri']
 

--- a/custom_components/spotcast/helpers.py
+++ b/custom_components/spotcast/helpers.py
@@ -3,6 +3,7 @@ import logging
 import requests
 import urllib
 import difflib
+import random
 from functools import partial, wraps
 
 from homeassistant.components.cast.media_player import CastDevice
@@ -80,7 +81,7 @@ def async_wrap(func):
 def get_search_results(search, spotify_client):
 
     _LOGGER.debug("using search query to find uri")
-    
+
     SEARCH_TYPES = ["artist", "album", "track", "playlist"]
 
     search = search.upper()
@@ -90,7 +91,7 @@ def get_search_results(search, spotify_client):
     for searchType in SEARCH_TYPES:
 
         try:
-    
+
             result = spotify_client.search(
                 searchType + ":" + search,
                 limit=1,
@@ -114,3 +115,13 @@ def get_search_results(search, spotify_client):
     _LOGGER.debug("Best match for %s is %s", search, bestMatch['name'])
 
     return bestMatch['uri']
+
+def get_random_playlist_from_category(spotify_client, category, country=None, limit=20):
+    _LOGGER.debug(f"Get random playlist among {limit} playlists from category {category} in country {country}")
+    playlists = spotify_client.category_playlists(category_id=category, country=country, limit=limit)["playlists"]["items"]
+    chosen = random.choice(playlists)
+    _LOGGER.debug(f"Choosed playlist {chosen['name']} ({chosen['uri']}) from category {category}.")
+
+    return chosen['uri']
+
+

--- a/custom_components/spotcast/services.yaml
+++ b/custom_components/spotcast/services.yaml
@@ -32,6 +32,29 @@ start:
       selector:
         text:
 
+    category:
+      name: "Category"
+      description: "A category to fetch playlist from. See https://developer.spotify.com/console/get-browse-categories/ for a list of categories"
+      required: false
+      selector:
+        text:
+    country:
+      name: "Country"
+      description: "Country code to use with category. See https://spotipy.readthedocs.io/en/2.19.0/#spotipy.client.Spotify.country_codes for list of available codes"
+      required: false
+      selector:
+        text:
+    limit:
+      name: "Limit"
+      description: "Limit of playlist to fetch in a given category. Default 20"
+      required: false
+      default: 20
+      selector:
+        number:
+          mode: box
+          step: 1
+          min: 0
+          max: 50
     search:
       name: "Search"
       description: "A Search request to the spotify API. Will play the most relevant search result."


### PR DESCRIPTION
This PR use the /category/ Spotify endpoint to pick up and play a random playlist of a given category.
I did not do it yet, but it should be fairly easy to create an entity which expose all the available categories.

3 new parameters are added, respectively:
* category : the category name
* country : 2 letter code of country to filter category
* limit : maximum number of playlist to return from api. Component will pick one randomly among them

Debug log level will show 2 lines:

```
home-assistant   | 2021-12-10 17:36:25 DEBUG (SyncWorker_4) [custom_components.spotcast.helpers] Get random playlist from 50 playlists of category chill, in country FR.
home-assistant   | 2021-12-10 17:36:25 DEBUG (SyncWorker_4) [custom_components.spotcast.helpers] Choosed playlist Peaceful Guitar (spotify:playlist:37i9dQZF1DX0jgyAiPl8Af) from category chill.
```

Maxence