### PR TITLE
Update required HA version in README & info.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Copy all files from custom_components/spotcast/ to custom_components/spotcast/ i
 
 ### Minimum Home Assistant version
 
-Spotcast is compatible with any version since 2021.4.1.
+Spotcast is compatible with any version since 2021.12.0.
 
 ### Official Spotify Integration
 

--- a/info.md
+++ b/info.md
@@ -14,7 +14,7 @@ Used by https://github.com/custom-cards/spotify-card.
 
 ## Minimum Home Assistant version
 
-Spotcast is compatible with any version since 2021.4.1.
+Spotcast is compatible with any version since 2021.12.0.
 
 ## Official Spotify integration
 


### PR DESCRIPTION
PR #271 raised the minimum required HA version to `2021.12.0`, this PR reflects this in the `README.md` & `info.md`