### PR TITLE
Add cast platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Home Assistant custom component to start Spotify playback on an idle chromecast device or a Spotify Connect device (thanks to @kleinc80) which means that you can target your automation for chromecast as well as connect devices.
 
+Spotcast implements a cast platform (requires Home Assistant Core 2022.2.0 or later), which enables Google Cast media player entities to play Spotify URI as well as to browse the Spotify library.
+
 This component is not meant to be a full Spotify chromecast media_player but only serves to start the playback. Controlling the chromecast device and the Spotify playback after the initial start is done in their respective components.
 Because starting playback using the API requires more powerful token the username and password used for browser login is used.
 

--- a/custom_components/spotcast/cast.py
+++ b/custom_components/spotcast/cast.py
@@ -1,0 +1,54 @@
+from collections.abc import Callable
+
+from homeassistant.components import spotify as ha_spotify
+from homeassistant.components.media_player import BrowseMedia
+from homeassistant.components.media_player.const import MEDIA_CLASS_APP
+import homeassistant.core as ha_core
+from pychromecast import Chromecast
+
+
+async def async_get_media_browser_root_object(
+    content_filter: Callable[[BrowseMedia], bool]
+):
+    return [
+        BrowseMedia(
+            title="Spotify",
+            media_class=MEDIA_CLASS_APP,
+            media_content_id="",
+            media_content_type="spotify",
+            thumbnail="https://brands.home-assistant.io/_/spotify/logo.png",
+            can_play=False,
+            can_expand=True,
+        )
+    ]
+
+
+async def async_browse_media(
+    hass: ha_core.HomeAssistant,
+    media_content_type: str,
+    media_content_id: str,
+    content_filter: Callable[[BrowseMedia], bool],
+):
+    if ha_spotify.is_spotify_media_type(media_content_type):
+        return await ha_spotify.async_browse_media(
+            hass, media_content_type, media_content_id, can_play_artist=False
+        )
+    if media_content_type == "spotify":
+        return await ha_spotify.async_browse_media(
+            hass, None, None, can_play_artist=False
+        )
+    return None
+
+
+async def async_play_media(
+    hass: ha_core.HomeAssistant,
+    cast_entity_id,
+    chromecast: Chromecast,
+    media_type: str,
+    media_id: str,
+):
+    if media_id and media_id.startswith("spotify:"):
+        data = {"entity_id": cast_entity_id, "uri": media_id}
+        await hass.services.async_call("spotcast", "start", data, blocking=False)
+        return True
+    return False

--- a/custom_components/spotcast/cast.py
+++ b/custom_components/spotcast/cast.py
@@ -7,9 +7,7 @@ import homeassistant.core as ha_core
 from pychromecast import Chromecast
 
 
-async def async_get_media_browser_root_object(
-    content_filter: Callable[[BrowseMedia], bool]
-):
+async def async_get_media_browser_root_object(cast_type: str) -> list[BrowseMedia]:
     """Create a root object for media browsing."""
     return [
         BrowseMedia(
@@ -28,8 +26,8 @@ async def async_browse_media(
     hass: ha_core.HomeAssistant,
     media_content_type: str,
     media_content_id: str,
-    content_filter: Callable[[BrowseMedia], bool],
-):
+    cast_type: str,
+) -> BrowseMedia | None:
     """Browse media."""
     if ha_spotify.is_spotify_media_type(media_content_type):
         return await ha_spotify.async_browse_media(

--- a/custom_components/spotcast/cast.py
+++ b/custom_components/spotcast/cast.py
@@ -46,7 +46,7 @@ async def async_play_media(
     chromecast: Chromecast,
     media_type: str,
     media_id: str,
-):
+) -> bool:
     """Play media."""
     if media_id and media_id.startswith("spotify:"):
         data = {"entity_id": cast_entity_id, "uri": media_id}

--- a/custom_components/spotcast/cast.py
+++ b/custom_components/spotcast/cast.py
@@ -10,6 +10,7 @@ from pychromecast import Chromecast
 async def async_get_media_browser_root_object(
     content_filter: Callable[[BrowseMedia], bool]
 ):
+    """Create a root object for media browsing."""
     return [
         BrowseMedia(
             title="Spotify",
@@ -29,6 +30,7 @@ async def async_browse_media(
     media_content_id: str,
     content_filter: Callable[[BrowseMedia], bool],
 ):
+    """Browse media."""
     if ha_spotify.is_spotify_media_type(media_content_type):
         return await ha_spotify.async_browse_media(
             hass, media_content_type, media_content_id, can_play_artist=False
@@ -47,6 +49,7 @@ async def async_play_media(
     media_type: str,
     media_id: str,
 ):
+    """Play media."""
     if media_id and media_id.startswith("spotify:"):
         data = {"entity_id": cast_entity_id, "uri": media_id}
         await hass.services.async_call("spotcast", "start", data, blocking=False)


### PR DESCRIPTION
Add cast platform to spotcast, this enables cast media_player to play spotify content as well as browse media.

Media browsing relies entirely on the native Spotify integration.
Note that account information is not yet supported by the native Spotify integration's media browser.

This will be supported in Home Assistant Core 2022.2 pending merge of https://github.com/home-assistant/core/pull/65149
The cast platform is ignored by previous versions of Home Assistant Core, so the change is backwards compatible.

Closes #233 

Screenshots:
![image](https://user-images.githubusercontent.com/14281572/151657618-29357ffd-268c-4e4c-b7ce-f5a5c65dc894.png)
![image](https://user-images.githubusercontent.com/14281572/151657640-3cf3c117-f122-42ea-b911-108c20d731c0.png)
![image](https://user-images.githubusercontent.com/14281572/151657662-d88bb121-be91-499c-879d-5e5ec47169da.png)


