### PR TITLE
Adapt cast platform to changes in HA Core 2022.3

### DIFF
--- a/custom_components/spotcast/cast.py
+++ b/custom_components/spotcast/cast.py
@@ -16,18 +16,9 @@ async def async_get_media_browser_root_object(
     cast_type: str
 ) -> list[BrowseMedia]:
     """Create a root object for media browsing."""
-    _LOGGER.debug("async_get_media_browser_root_object")
-    return [
-        BrowseMedia(
-            title="Spotify",
-            media_class=MEDIA_CLASS_APP,
-            media_content_id="",
-            media_content_type="spotify",
-            thumbnail="https://brands.home-assistant.io/_/spotify/logo.png",
-            can_play=False,
-            can_expand=True,
-        )
-    ]
+    result = await ha_spotify.async_browse_media(hass, None, None)
+    _LOGGER.debug("async_get_media_browser_root_object return %s", result.children)
+    return result.children
 
 
 async def async_browse_media(
@@ -48,11 +39,6 @@ async def async_browse_media(
         # Browse deeper in the tree
         result = await ha_spotify.async_browse_media(
             hass, media_content_type, media_content_id, can_play_artist=False
-        )
-    if media_content_type == "spotify":
-        # Browse the root node created by async_get_media_browser_root_object
-        result = await ha_spotify.async_browse_media(
-            hass, None, None, can_play_artist=False
         )
     _LOGGER.debug(
         "async_browse_media return: %s",
@@ -77,7 +63,9 @@ async def async_play_media(
     # If this is a spotify URI, forward to the the spotcast.start service, if not return
     # False
     if media_id and media_id.startswith("spotify:"):
-        data = {"entity_id": cast_entity_id, "uri": media_id}
+        # Get the spotify URI
+        spotify_uri = ha_spotify.spotify_uri_from_media_browser_url(media_id)
+        data = {"entity_id": cast_entity_id, "uri": spotify_uri}
         await hass.services.async_call("spotcast", "start", data, blocking=False)
         return True
     return False

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Spotcast",
   "domains": ["media_player", "sensor"],
-  "homeassistant": "2021.12.0",
+  "homeassistant": "2022.3.0",
   "iot_class": ["Cloud Polling"]
 }


### PR DESCRIPTION
Changes:
- Adapt cast platform to changes in HA Core 2022.3
- Bump minimum homeassistant version to 2022.3.0

Background:
HA Core 2022.3 allows browsing multiple Spotify account, this was introduced by https://github.com/home-assistant/core/pull/66256