### PR TITLE
Moved uri validation to before split

### DIFF
--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -175,15 +175,15 @@ def setup(hass: ha_core.HomeAssistant, config: collections.OrderedDict) -> bool:
             # remove ? from badly formatted URI
             uri = uri.split("?")[0]
 
+            if not helpers.is_valid_uri(uri):
+                _LOGGER.error("Invalid URI provided, aborting casting")
+                return
+
             # force first two elements of uri to lowercase
             uri = uri.split(":")
             uri[0] = uri[0].lower()
             uri[1] = uri[1].lower()
             uri = ':'.join(uri)
-
-            if not helpers.is_valid_uri(uri):
-                _LOGGER.error("Invalid URI provided, aborting casting")
-                return
 
         # first, rely on spotify id given in config otherwise get one
         if not spotify_device_id:


### PR DESCRIPTION
Issue https://github.com/fondberg/spotcast/issues/335 seems to caused by a malformed URI. If the URI does not contain three element separated by `:`, an `IndexError` results.

This PR moves the `helpers.is_valid_uri(uri)` up a few lines to catch malformed URIs before they result in an `IndexError`.