### PR TITLE
Give spotify the chance to wake up devices

### DIFF
--- a/custom_components/spotcast/spotcast_controller.py
+++ b/custom_components/spotcast/spotcast_controller.py
@@ -208,9 +208,21 @@ class SpotcastController:
             me_resp = client._get("me")
             spotify_cast_device.startSpotifyController(access_token, expires)
             # Make sure it is started
-            spotify_device_id = spotify_cast_device.getSpotifyDeviceId(
-                get_spotify_devices(self.hass, me_resp["id"])
-            )
+            try:
+                spotify_device_id = spotify_cast_device.getSpotifyDeviceId(
+                   get_spotify_devices(self.hass, me_resp["id"])
+                )
+            except HomeAssistantError as e:
+                # Some devices might need to get woken up first, so try again
+                if str(e) != "Failed to get device id from Spotify":
+                    raise e
+
+                time.sleep(2)
+
+                spotify_device_id = spotify_cast_device.getSpotifyDeviceId(
+                   get_spotify_devices(self.hass, me_resp["id"])
+                )
+                
         return spotify_device_id
 
     def play(


### PR DESCRIPTION
Retry the spotify device list if a device is missing so spotify can wake up some devices like chromecasts.