### PR TITLE
WIP: 334 spotify device not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,5 @@ venv.bak/
 .mypy_cache/
 
 .vscode
+
+.idea/

--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -175,15 +175,15 @@ def setup(hass: ha_core.HomeAssistant, config: collections.OrderedDict) -> bool:
             # remove ? from badly formatted URI
             uri = uri.split("?")[0]
 
+            if not helpers.is_valid_uri(uri):
+                _LOGGER.error("Invalid URI provided, aborting casting")
+                return
+
             # force first two elements of uri to lowercase
             uri = uri.split(":")
             uri[0] = uri[0].lower()
             uri[1] = uri[1].lower()
             uri = ':'.join(uri)
-
-            if not helpers.is_valid_uri(uri):
-                _LOGGER.error("Invalid URI provided, aborting casting")
-                return
 
         # first, rely on spotify id given in config otherwise get one
         if not spotify_device_id:

--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -175,15 +175,15 @@ def setup(hass: ha_core.HomeAssistant, config: collections.OrderedDict) -> bool:
             # remove ? from badly formatted URI
             uri = uri.split("?")[0]
 
-            if not helpers.is_valid_uri(uri):
-                _LOGGER.error("Invalid URI provided, aborting casting")
-                return
-
             # force first two elements of uri to lowercase
             uri = uri.split(":")
             uri[0] = uri[0].lower()
             uri[1] = uri[1].lower()
             uri = ':'.join(uri)
+
+            if not helpers.is_valid_uri(uri):
+                _LOGGER.error("Invalid URI provided, aborting casting")
+                return
 
         # first, rely on spotify id given in config otherwise get one
         if not spotify_device_id:

--- a/custom_components/spotcast/helpers.py
+++ b/custom_components/spotcast/helpers.py
@@ -7,10 +7,12 @@ import urllib
 import difflib
 import random
 from functools import partial, wraps
+import homeassistant.core as ha_core
 
 from homeassistant.components.cast.media_player import CastDevice
 from homeassistant.components.spotify.media_player import SpotifyMediaPlayer
 from homeassistant.helpers import entity_platform
+from homeassistant.exceptions import HomeAssistantError
 
 # import for type inference
 import spotipy
@@ -18,7 +20,10 @@ import spotipy
 _LOGGER = logging.getLogger(__name__)
 
 
-def get_spotify_devices(hass, spotify_user_id):
+def get_spotify_media_player(hass: ha_core.HomeAssistant, spotify_user_id: str) -> SpotifyMediaPlayer:
+    """
+    Get the spotify media player entity from hass.
+    """
     platforms = entity_platform.async_get_platforms(hass, "spotify")
     spotify_media_player = None
     for platform in platforms:
@@ -41,15 +46,25 @@ def get_spotify_devices(hass, spotify_user_id):
                 break
 
     if spotify_media_player:
+        return spotify_media_player
+    else:
+        raise HomeAssistantError("Could not find spotify media player.")
+
+
+def get_spotify_devices(spotify_media_player: [entity_platform.EntityPlatform]) -> list:
+    """
+    Attempt to retrieve available devices from the Spotify service.
+    """
+    if spotify_media_player:
         # Need to come from media_player spotify's sp client due to token issues
         try:
-            resp = spotify_media_player._spotify.devices()
-        except(AttributeError):
-            resp = spotify_media_player.data.client.devices()
-
-        _LOGGER.debug("get_spotify_devices: %s", resp)
+            devices_available = spotify_media_player._spotify.devices()
+        except AttributeError:
+            devices_available = spotify_media_player.data.client.devices()
         
-        return resp
+        return devices_available
+    return []
+
 
 def get_spotify_install_status(hass):
 

--- a/custom_components/spotcast/spotcast_controller.py
+++ b/custom_components/spotcast/spotcast_controller.py
@@ -120,8 +120,8 @@ class SpotifyCastDevice:
                 if spotify_device["id"] == self.spotifyController.device:
                     spotify_device = spotify_device["id"]
                     break
-            # Exponential backoff with some jitter
-            sleep = random.uniform(1.5, 2.5) ** counter
+            # Exponential backoff with some jitter, total loop time between ~19s to ~40s
+            sleep = random.uniform(1.5, 1.8) ** counter
             time.sleep(sleep)
         _LOGGER.debug(f"Devices available on spotify: {devices_available}")
 


### PR DESCRIPTION
Here's a different suggested fix to #334, where spotify is not aware of a recently booted chromecast device.

This fix adds a retry loop an exponential backoff with a jittered base, max 5 retries.

Total sleep time between ~19s - ~40s, requests sent on average 1.6s, 4.4s, 8.9s, 16s, 28s after loop start.
```
Time length of retry loop, 
-|---|----|-------|----------|
 *   *    *       *          *
* = request
```