### PR TITLE
Improved search functionality

### DIFF
--- a/custom_components/spotcast/const.py
+++ b/custom_components/spotcast/const.py
@@ -13,6 +13,7 @@ CONF_SPOTIFY_DEVICE_ID = "spotify_device_id"
 CONF_DEVICE_NAME = "device_name"
 CONF_SPOTIFY_URI = "uri"
 CONF_SPOTIFY_SEARCH = "search"
+CONF_SPOTIFY_ARTISTNAME = "artistName"
 CONF_SPOTIFY_CATEGORY = "category"
 CONF_SPOTIFY_COUNTRY = "country"
 CONF_SPOTIFY_LIMIT = "limit"
@@ -76,6 +77,7 @@ SERVICE_START_COMMAND_SCHEMA = vol.Schema(
         vol.Optional(CONF_ENTITY_ID): cv.string,
         vol.Optional(CONF_SPOTIFY_URI): cv.string,
         vol.Optional(CONF_SPOTIFY_SEARCH): cv.string,
+        vol.Optional(CONF_SPOTIFY_ARTISTNAME): cv.string,
         vol.Optional(CONF_SPOTIFY_CATEGORY): cv.string,
         vol.Optional(CONF_SPOTIFY_COUNTRY): cv.string,
         vol.Optional(CONF_SPOTIFY_LIMIT, default=20): cv.positive_int,

--- a/custom_components/spotcast/services.yaml
+++ b/custom_components/spotcast/services.yaml
@@ -61,6 +61,13 @@ start:
       required: false
       selector:
         text:
+    artistName:
+      name: "Artist Name"
+      example: "pink floyd"
+      description: "This will filter search results to match the provided artist name"
+      required: false
+      selector:
+        text:
     account:
       name: "Account"
       description: "Optionally starts Spotify using an alternative account specified in config."


### PR DESCRIPTION
Modified the existing search functionality. Changes -

1. New "Artist" field to specify which artist to play
2. If no search string provided and only an "Artist" is provided - it plays the top tracks of that Artist. Adds the top tracks to the player queue
3. If search string and artist fields are filled - it searches better by matching tracks with the provided artist name
4. If the "artist" field is not used - it uses the standard search approach. But now adds tracks to the queue (defined by limit parameter)

Now you can search for cover songs....for example -
search: Master of puppets
artist: Dream Theater