### PR TITLE
Add support for playing back from the user's library

### DIFF
--- a/custom_components/spotcast/helpers.py
+++ b/custom_components/spotcast/helpers.py
@@ -176,6 +176,15 @@ def is_valid_uri(uri: str) -> bool:
     elems = uri.split(":")
 
     # validate number of sub elements
+    if elems[1].lower() == "user":
+        elems = elems[0:1] + elems[3:]
+        types = [ "playlist" ]
+        _LOGGER.debug(f"Excluding user information from the Spotify URI validation. Only supported for playlists")
+
+    # support playing a user's liked songs list (spotify:user:username:collection)
+    if len(elems) == 2 and elems[1].lower() == "collection":
+        return True
+
     if len(elems) != 3:
         _LOGGER.error(f"[{uri}] is not a valid URI. The format should be [spotify:<type>:<unique_id>]")
         return False

--- a/custom_components/spotcast/spotcast_controller.py
+++ b/custom_components/spotcast/spotcast_controller.py
@@ -270,6 +270,9 @@ class SpotcastController:
                 elif uri.find("playlist") > 0:
                     results = client.playlist_tracks(uri)
                     position = random.randint(0, results["total"] - 1)
+                elif uri.find("collection") > 0:
+                    results = client.current_user_saved_tracks()
+                    position = random.randint(0, results["total"] - 1)
                 _LOGGER.debug("Start playback at random position: %s", position)
             if uri.find("artist") < 1:
                 kwargs["offset"] = {"position": position}


### PR DESCRIPTION
Spotify supports playing back from a user's library of saved tracks using the following URI:
```
spotify:user:username:collection
```

While not a super common (or likely) use case, it also supports including the user in a playlist URI, as follows:
```
spotify:user:username:playlist:playlistId
```

This change adds support for the above two cases by updating the URI validation to take into account a user field in the URI, and adds support for playback from a random saved track by looking up the total number saved.