### PR TITLE
Remove last_update to save on database space

### DIFF
--- a/custom_components/spotcast/sensor.py
+++ b/custom_components/spotcast/sensor.py
@@ -9,7 +9,6 @@ import homeassistant.core as ha_core
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import STATE_OK, STATE_UNKNOWN
-from homeassistant.util import dt
 
 from .helpers import get_cast_devices
 from .const import (
@@ -74,7 +73,6 @@ class ChromecastDevicesSensor(SensorEntity):
 
         self._attributes["devices_json"] = json.dumps(chromecasts, ensure_ascii=False)
         self._attributes["devices"] = chromecasts
-        self._attributes["last_update"] = dt.now().isoformat("T")
         self._state = STATE_OK
 
 
@@ -118,5 +116,4 @@ class ChromecastPlaylistSensor(SensorEntity):
         )
         self._attributes["playlists"] = [{ "uri": x['uri'], "name": x['name']} for x in resp['items'] ]
 
-        self._attributes["last_update"] = dt.now().isoformat("T")
         self._state = STATE_OK


### PR DESCRIPTION
sensor.playlist_sensor fills up the HA database due to the last_update attribute changing every minute. The list of playlists does not change very frequently so this feels unnecessary to pepper the database with the info. 

Alternatives, the update frequency could be lowered for the playlist sensor. Say hourly updates. Or the last_update attribute could be made optional via the config flow options. I'm happy to write the PR for these if one solution is preferred.