### PR TITLE
handle spotify web URLs as well

### DIFF
--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -56,6 +56,7 @@ from .helpers import (
     get_random_playlist_from_category,
     get_search_results,
     is_valid_uri,
+    url_to_spotify_uri,
 )
 
 from .spotcast_controller import SpotcastController
@@ -228,6 +229,14 @@ def setup(hass: ha_core.HomeAssistant, config: collections.OrderedDict) -> bool:
 
             # remove ? from badly formatted URI
             uri = uri.split("?")[0]
+
+            if uri.startswith("http"):
+                try:
+                    u = url_to_spotify_uri(uri)
+                    _LOGGER.debug("converted web URL %s to spotify URI %s", uri, u)
+                    uri = u
+                except ValueError:
+                    _LOGGER.error("invalid web URL provided, could not convert to spotify URI: %s", uri)
 
             if not is_valid_uri(uri):
                 _LOGGER.error("Invalid URI provided, aborting casting")

--- a/custom_components/spotcast/helpers.py
+++ b/custom_components/spotcast/helpers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import requests
-import urllib
+import urllib.parse
 import difflib
 import random
 from functools import partial, wraps
@@ -170,6 +170,26 @@ def get_random_playlist_from_category(spotify_client:spotipy.Spotify, category:s
     _LOGGER.debug(f"Chose playlist {chosen['name']} ({chosen['uri']}) from category {category}.")
 
     return chosen['uri']
+
+
+def url_to_spotify_uri(url: str) -> str:
+    """
+    Convert a spotify web url (e.g. https://open.spotify.com/track/XXXX) to
+    a spotify-style URI (spotify:track:XXXX). Returns None on error.
+    """
+
+    o: urllib.parse.ParseResult
+    # will raise ValueError if URL is invalid
+    o = urllib.parse.urlparse(url)
+
+    if o.hostname != "open.spotify.com":
+        raise ValueError('Spotify URLs must have a hostname of "open.spotify.com"')
+
+    path = o.path.split("/")
+    if len(path) != 3:
+        raise ValueError('Spotify URLs must be of the form "https://open.spotify.com/<kind>/<target>"')
+
+    return f'spotify:{path[1]}:{path[2]}'
 
 def is_valid_uri(uri: str) -> bool:
     


### PR DESCRIPTION
This automatically converts spotify web URLs (e.g. https://open.spotify.com/track/XXX) to spotify URIs.

This is particularly useful to me, since I have a NFC-tag jukebox for the kids to use. And it's much easier to write a standard URL to an NFC tag rather than changing it to a spotify URI.

Thanks!