### PR TITLE
Make podcasts work sanely.

### DIFF
--- a/custom_components/spotcast/const.py
+++ b/custom_components/spotcast/const.py
@@ -24,7 +24,6 @@ CONF_SHUFFLE = "shuffle"
 CONF_SP_DC = "sp_dc"
 CONF_SP_KEY = "sp_key"
 CONF_START_VOL = "start_volume"
-CONF_IGNORE_FULLY_PLAYED = "ignore_fully_played"
 
 WS_TYPE_SPOTCAST_PLAYLISTS = "spotcast/playlists"
 
@@ -86,7 +85,6 @@ SERVICE_START_COMMAND_SCHEMA = vol.Schema(
         vol.Optional(CONF_SHUFFLE, default=False): cv.boolean,
         vol.Optional(CONF_OFFSET, default=0): cv.string,
         vol.Optional(CONF_START_VOL, default=101): cv.positive_int,
-        vol.Optional(CONF_IGNORE_FULLY_PLAYED, default=False): cv.boolean,
     }
 )
 

--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -1,18 +1,18 @@
 {
   "domain": "spotcast",
   "name": "Spotcast",
-  "documentation": "https://github.com/fondberg/spotcast",
-  "issue_tracker": "https://github.com/fondberg/spotcast/issues",
-  "iot_class": "cloud_polling",
-  "version": "v3.6.30",
-  "dependencies": [
-    "spotify"
-  ],
   "after_dependencies": [
     "cast",
     "spotify"
   ],
   "codeowners": [
     "@fondberg"
-  ]
+  ],
+  "dependencies": [
+    "spotify"
+  ],
+  "documentation": "https://github.com/fondberg/spotcast",
+  "iot_class": "cloud_polling",
+  "issue_tracker": "https://github.com/fondberg/spotcast/issues",
+  "version": "v3.6.30"
 }

--- a/custom_components/spotcast/services.yaml
+++ b/custom_components/spotcast/services.yaml
@@ -127,11 +127,3 @@ start:
           step: 1
           min: 0
           max: 100
-    ignore_fully_played:
-      name: "Ignore Fully Played"
-      description: "Set to ignore or not already played episodes in a podcast playlist"
-      example: true
-      required: false
-      default: false
-      selector:
-        boolean:

--- a/custom_components/spotcast/services.yaml
+++ b/custom_components/spotcast/services.yaml
@@ -106,7 +106,7 @@ start:
         boolean:
     offset:
       name: "Offset"
-      description: "Set offset mode for playback. 0 is the first song."
+      description: "Set offset mode for playback. 0 is the first song (or 1 for latest unplayed episode)."
       example: 1
       required: false
       default: 0

--- a/custom_components/spotcast/spotcast_controller.py
+++ b/custom_components/spotcast/spotcast_controller.py
@@ -259,7 +259,6 @@ class SpotcastController:
         uri: str,
         random_song: bool,
         position: str,
-        ignore_fully_played: str,
         country_code: str = None
     ) -> None:
         _LOGGER.debug(

--- a/custom_components/spotcast/spotcast_controller.py
+++ b/custom_components/spotcast/spotcast_controller.py
@@ -269,22 +269,28 @@ class SpotcastController:
         )
 
         if uri.find("show") > 0:
-            show_episodes_info = client.show_episodes(uri, market=country_code)
-            if show_episodes_info and len(show_episodes_info["items"]) > 0:
-                if ignore_fully_played:
+            show_info = client.show(uri, market=country_code)
+            limit=50 # maximum allowed
+            if show_info and show_info["episodes"]["total"] > 0:
+                play_episode = None
+                offset = show_info["episodes"]["total"] - limit
+                while play_episode is None:
+                    show_episodes_info = client.show_episodes(uri, limit=limit,offset=offset,market=country_code)
+                    _LOGGER.debug("Retrived %s episodes of %s starting at %s",len(show_episodes_info["items"]),show_info["name"],offset)
+                    show_episodes_info["items"].reverse()
+                    ep_pos = limit+offset
                     for episode in show_episodes_info["items"]:
-                        if not episode["resume_point"]["fully_played"]:
-                            episode_uri = episode["external_urls"]["spotify"]
-                            break
-                else:
-                    episode_uri = show_episodes_info["items"][0]["external_urls"][
-                        "spotify"
-                    ]
-                _LOGGER.debug(
-                    "Playing episode using uris (latest podcast playlist)= for uri: %s",
-                    episode_uri,
-                )
-                client.start_playback(device_id=spotify_device_id, uris=[episode_uri])
+                        episode['offset_position'] = ep_pos
+                        ep_pos = ep_pos - 1
+                        if episode["resume_point"]["fully_played"] is False:
+                           play_episode = episode
+                           break
+                    if offset == 0:
+                      play_episode = show_episodes_info["items"][-1]
+                      break
+                    offset = max(0,offset-limit)
+                _LOGGER.debug("Playing episode: %s  offset: %s Resume Position: %s", episode["name"],play_episode["offset_position"],play_episode["resume_point"]["resume_position_ms"])
+                client.start_playback(device_id=spotify_device_id, context_uri=uri,offset={ "position": play_episode["offset_position"]},position_ms=play_episode["resume_point"]["resume_position_ms"])
         elif uri.find("episode") > 0:
             _LOGGER.debug("Playing episode using uris= for uri: %s", uri)
             client.start_playback(device_id=spotify_device_id, uris=[uri])


### PR DESCRIPTION
This PR changes podcasts to work as any user would expect - it plays the podcast (not an episode - which is what it was doing), and it plays it from the first episode that hasn't been fully played, resumed at the point it was.

The previous way it worked would only ever play a single episode and then stop, and it didn't work in ways any user would reasonably expect - I have therefore also removed the ignore_fully_played option. I have added the position == 1 overload, which makes it search backwards, playing the latest unplayed episode first.

The main issue here is that you need to go through all the episodes and count the number yourself - you can't play a show with the uri of an episode. It works, but it's terrible. 
