### PR TITLE
Construct Spotify deviceID required for device auth refresh endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,4 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+.vscode/

--- a/custom_components/spotcast/spotcast_controller.py
+++ b/custom_components/spotcast/spotcast_controller.py
@@ -90,7 +90,7 @@ class SpotifyCastDevice:
         )
 
     def startSpotifyController(self, access_token: str, expires: int) -> None:
-        sp = SpotifyController(access_token, expires)
+        sp = SpotifyController(self.castDevice, access_token, expires)
         self.castDevice.register_handler(sp)
         sp.launch_app()
 


### PR DESCRIPTION
Fixes issue https://github.com/fondberg/spotcast/issues/398, where `deviceID` is missing in the response from the Spotify API.
The `devideID` is actually a `md5` hash of the `friendly_name` of the Chromecast. This PR should fix the current existing errors on the `deviceID` missing from the data in the response.