### PR TITLE
Check for 302 status with a redirect to &_authfailed=1 in token request

### DIFF
--- a/custom_components/spotcast/spotcast_controller.py
+++ b/custom_components/spotcast/spotcast_controller.py
@@ -208,6 +208,14 @@ class SpotifyToken:
                 allow_redirects=False,
                 headers=headers
             ) as response:
+                if (response.status == 302 and response.headers['Location'] == '/get_access_token?reason=transport&productType=web_player&_authfailed=1'):
+                    _LOGGER.error(
+                        "Unsuccessful token request, received code 302 and "
+                        "Location header %s. sp_dc and sp_key could be "
+                        "expired. Please update in config.",
+                        response.headers['Location']
+                    )
+                    raise HomeAssistantError("Expired sp_dc, sp_key")
                 if (response.status != 200):
                     _LOGGER.info(
                         "Unsuccessful token request, received code %i",


### PR DESCRIPTION
My cookies was expired, and I noticed that this time, it was not caught by the `except TooManyRedirects:` catch block. However, the logs gave me just info that we had a 302 response.
I found that this response had a Location-header pointing to `/get_access_token?reason=transport&productType=web_player&_authfailed=1`.
I figured it would be useful to check for this and give some more errors in the logs.