### PR TITLE
Improved/Extended search functionality

### DIFF
--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -27,6 +27,8 @@ from .const import (
     CONF_SPOTIFY_DEVICE_ID,
     CONF_SPOTIFY_URI,
     CONF_SPOTIFY_SEARCH,
+    CONF_SPOTIFY_ARTISTNAME,
+    CONF_SPOTIFY_SEARCHTYPE,
     CONF_SPOTIFY_CATEGORY,
     CONF_SPOTIFY_COUNTRY,
     CONF_SPOTIFY_LIMIT,
@@ -47,6 +49,7 @@ from .const import (
 )
 
 from .helpers import (
+    add_tracks_to_queue,
     async_wrap,
     get_cast_devices,
     get_spotify_devices,
@@ -55,6 +58,7 @@ from .helpers import (
     is_empty_str,
     get_random_playlist_from_category,
     get_search_results,
+    search_tracks,
     is_valid_uri,
 )
 
@@ -179,6 +183,8 @@ def setup(hass: ha_core.HomeAssistant, config: collections.OrderedDict) -> bool:
         country = call.data.get(CONF_SPOTIFY_COUNTRY)
         limit = call.data.get(CONF_SPOTIFY_LIMIT)
         search = call.data.get(CONF_SPOTIFY_SEARCH)
+        artistName = call.data.get(CONF_SPOTIFY_ARTISTNAME)
+        searchType = call.data.get(CONF_SPOTIFY_SEARCHTYPE)
         random_song = call.data.get(CONF_RANDOM, False)
         repeat = call.data.get(CONF_REPEAT, False)
         shuffle = call.data.get(CONF_SHUFFLE, False)
@@ -222,7 +228,7 @@ def setup(hass: ha_core.HomeAssistant, config: collections.OrderedDict) -> bool:
                 account, spotify_device_id, device_name, entity_id
             )
 
-        if is_empty_str(uri) and is_empty_str(search) and is_empty_str(category):
+        if is_empty_str(uri) and is_empty_str(search) and is_empty_str(artistName) and is_empty_str(category):
             _LOGGER.debug("Transfering playback")
             current_playback = client.current_playback()
             if current_playback is not None:
@@ -248,10 +254,16 @@ def setup(hass: ha_core.HomeAssistant, config: collections.OrderedDict) -> bool:
                 ignore_fully_played,
             )
         else:
-
+            searchResults = []
             if is_empty_str(uri):
                 # get uri from search request
-                uri = get_search_results(search, client, country)
+                #uri = get_search_results(search, client, country)
+                if is_empty_str(searchType):
+                    searchType = "track"
+                searchResults = search_tracks(search, client, False, shuffle, random_song, limit, artistName, searchType, country)
+                # play the first track
+                if len(searchResults) > 0:
+                    uri = searchResults[0]['uri']
 
             spotcast_controller.play(
                 client,
@@ -261,6 +273,9 @@ def setup(hass: ha_core.HomeAssistant, config: collections.OrderedDict) -> bool:
                 position,
                 ignore_fully_played,
             )
+
+            if len(searchResults) > 1:
+                add_tracks_to_queue(client, searchResults[1:len(searchResults)])
 
         if start_volume <= 100:
             _LOGGER.debug("Setting volume to %d", start_volume)

--- a/custom_components/spotcast/const.py
+++ b/custom_components/spotcast/const.py
@@ -13,6 +13,8 @@ CONF_SPOTIFY_DEVICE_ID = "spotify_device_id"
 CONF_DEVICE_NAME = "device_name"
 CONF_SPOTIFY_URI = "uri"
 CONF_SPOTIFY_SEARCH = "search"
+CONF_SPOTIFY_ARTISTNAME = "artistName"
+CONF_SPOTIFY_SEARCHTYPE = "searchType"
 CONF_SPOTIFY_CATEGORY = "category"
 CONF_SPOTIFY_COUNTRY = "country"
 CONF_SPOTIFY_LIMIT = "limit"
@@ -76,6 +78,8 @@ SERVICE_START_COMMAND_SCHEMA = vol.Schema(
         vol.Optional(CONF_ENTITY_ID): cv.string,
         vol.Optional(CONF_SPOTIFY_URI): cv.string,
         vol.Optional(CONF_SPOTIFY_SEARCH): cv.string,
+        vol.Optional(CONF_SPOTIFY_ARTISTNAME): cv.string,
+        vol.Optional(CONF_SPOTIFY_SEARCHTYPE): cv.string,
         vol.Optional(CONF_SPOTIFY_CATEGORY): cv.string,
         vol.Optional(CONF_SPOTIFY_COUNTRY): cv.string,
         vol.Optional(CONF_SPOTIFY_LIMIT, default=20): cv.positive_int,

--- a/custom_components/spotcast/helpers.py
+++ b/custom_components/spotcast/helpers.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import requests
 import urllib
+import time
 import difflib
 import random
 from functools import partial, wraps
@@ -103,44 +104,105 @@ def async_wrap(func):
 
     return run
 
-def get_search_results(search:str, spotify_client:spotipy.Spotify, country:str=None) -> str:
+def get_top_tracks(artistName:str, spotify_client:spotipy.Spotify, limit:int=20, country:str = None):
 
+    _LOGGER.debug("Searching for top tracks for the artist: %s", artistName)
+    searchType = "artist"
+    search = searchType + ":" + artistName
+
+    artistUri = ""
+
+    # get artist uri
+    try:
+
+        artist = spotify_client.search(
+            artistName,
+            limit=1,
+            offset=0,
+            type="artist",
+            market=country)["artists"]['items'][0]
+
+        _LOGGER.debug("found artist %s: %s", artist['name'], artist['uri'])
+        artistUri = artist['uri']
+
+    except IndexError:
+        pass
+
+    results = spotify_client.artist_top_tracks(artistUri)
+    for track in results['tracks'][:10]:
+        _LOGGER.debug('track    : ' + track['name'])
+
+    return results['tracks']
+
+def get_search_string(search:str, artistName:str) -> str:
+    finalString = search.upper()
+    if not is_empty_str(artistName):
+        finalString += " artist:" + artistName
+    return finalString
+
+def get_search_results(search:str, spotify_client:spotipy.Spotify, artistName:str=None, limit:int=10, searchType:str=None, country:str=None):
     _LOGGER.debug("using search query to find uri")
+    searchResults = []
 
-    SEARCH_TYPES = ["artist", "album", "track", "playlist"]
-
-    search = search.upper()
-
-    results = []
-
-    for searchType in SEARCH_TYPES:
+    if is_empty_str(search) and artistName != None:
+        searchResults = get_top_tracks(artistName, spotify_client)
+        _LOGGER.debug("Playing top tracks for artist: %s", searchResults[0]['name'])
+    else:
+        # Get search type
+        if searchType == "tracks" and not is_empty_str(artistName):
+            search = get_search_string(search, artistName)
+        
+        resultKey = "playlists" if searchType == "playlist" else "tracks"
 
         try:
-
-            result = spotify_client.search(
-                searchType + ":" + search,
-                limit=1,
+            searchResults = spotify_client.search(
+                search,
+                limit,
                 offset=0,
                 type=searchType,
-                market=country)[searchType + 's']['items'][0]
-
-            results.append(
-                {
-                    'name': result['name'].upper(),
-                    'uri': result['uri']
-                }
-            )
-
-            _LOGGER.debug("search result for %s: %s", searchType, result['name'])
-
+                market=country)[resultKey]['items']
         except IndexError:
             pass
+        
+        if searchType == "playlist":    
+            tempResults = searchResults
+            searchResults = []
+            for result in tempResults:
+                if result["name"].lower() == search.lower() or result["name"].lower() in search.lower():
+                    searchResults = [
+                        result
+                    ]
+                    break
+        
+        if len(searchResults) > 0:
+            _LOGGER.debug("Found %d results for %s. First item name: %s", len(searchResults), search, searchResults[0]['name'])
 
-    bestMatch = sorted(results, key=lambda x: difflib.SequenceMatcher(None, x['name'], search).ratio(), reverse=True)[0]
+    return searchResults
 
-    _LOGGER.debug("Best match for %s is %s", search, bestMatch['name'])
+def search_tracks(search:str, spotify_client:spotipy.Spotify,
+                            appendToQueue:bool=False, shuffle:bool=False, startRandom:bool=False,
+                            limit:int=20, artistName:str=None, searchType:str=None, country:str=None):
+    results = get_search_results(search, spotify_client, artistName, limit, searchType, country)
+    if len(results) > 0:
+        firstResult = [results[0]]
+        if not startRandom:
+            results = results[1:limit]
+        if shuffle:
+            random.shuffle(results)
+        if not startRandom:
+            results = firstResult + results
 
-    return bestMatch['uri']
+    return results
+
+def add_tracks_to_queue(spotify_client:spotipy.Spotify, tracks:list=[], limit:int=20):
+    if len(tracks) == 0:
+        _LOGGER.debug("Cannot add ZERO tracks to the queue!")
+        return
+
+    for track in tracks[:limit]:
+        _LOGGER.debug("Adding " + track['name'] + " to the playback queue | " + track['uri'])
+        spotify_client.add_to_queue(track['uri'])
+        time.sleep(0.5)
 
 def get_random_playlist_from_category(spotify_client:spotipy.Spotify, category:str, country:str=None, limit:int=20) -> str:
     

--- a/custom_components/spotcast/services.yaml
+++ b/custom_components/spotcast/services.yaml
@@ -62,6 +62,22 @@ start:
       required: false
       selector:
         text:
+    artistName:
+      name: "Artist Name"
+      example: "pink floyd"
+      description: "This will filter search results to match the provided artist name"
+      required: false
+      selector:
+        text:
+    searchType:
+      name: "Search Type"
+      description: "This is the type of search."
+      default: "track"
+      selector:
+        select:
+          options:
+            - "track"
+            - "playlist"
     account:
       name: "Account"
       description: "Optionally starts Spotify using an alternative account specified in config."


### PR DESCRIPTION
From https://github.com/fondberg/spotcast/pull/363
Updated this PR for current code state.
```
Modified the existing search functionality. Changes -

New "Artist" field to specify which artist to play
If no search string provided and only an "Artist" is provided - it plays the top tracks of that Artist. Adds the top tracks to the player queue
If search string and artist fields are filled - it searches better by matching tracks with the provided artist name
If the "artist" field is not used - it uses the standard search approach. But now adds tracks to the queue (defined by limit parameter)
Now you can search for cover songs....for example -
search: Master of puppets
artist: Dream Theater
```
Added searchType which takes `track` or `playlist` values to search for whole playlists as well.