### PR TITLE
Fixes missing import from pychromecast.

### DIFF
--- a/custom_components/spotcast/error.py
+++ b/custom_components/spotcast/error.py
@@ -1,0 +1,5 @@
+class LaunchError(Exception):
+    """When an app fails to launch."""
+
+class TokenError(Exception):
+    pass

--- a/custom_components/spotcast/spotcast_controller.py
+++ b/custom_components/spotcast/spotcast_controller.py
@@ -18,6 +18,7 @@ from homeassistant.components.cast.helpers import ChromeCastZeroconf
 from homeassistant.exceptions import HomeAssistantError
 
 from .spotify_controller import SpotifyController
+from .error import TokenError
 from .const import CONF_SP_DC, CONF_SP_KEY
 from .helpers import (
     get_cast_devices,
@@ -26,10 +27,6 @@ from .helpers import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class TokenError(Exception):
-    pass
 
 
 class SpotifyCastDevice:

--- a/custom_components/spotcast/spotify_controller.py
+++ b/custom_components/spotcast/spotify_controller.py
@@ -10,9 +10,9 @@ import json
 import hashlib
 
 from .const import APP_SPOTIFY
+from .error import LaunchError
 
 from pychromecast.controllers import BaseController
-from pychromecast.error import LaunchError
 
 APP_NAMESPACE = "urn:x-cast:com.spotify.chromecast.secure.v1"
 TYPE_GET_INFO = "getInfo"


### PR DESCRIPTION
The `LaunchError` exception [was removed](https://github.com/home-assistant-libs/pychromecast/pull/835) from pychromecast in the version used by home assistant >=2024.3.0b0