### PR TITLE
Fix for new pychromecast version

### DIFF
--- a/custom_components/spotcast/spotify_controller.py
+++ b/custom_components/spotcast/spotify_controller.py
@@ -54,9 +54,15 @@ class SpotifyController(BaseController):
                 'content-type': 'text/plain;charset=UTF-8'
             }
 
-            request_body = json.dumps({'clientId': self.client, 'deviceId': self.device})
+            request_body = json.dumps(
+                {'clientId': self.client, 'deviceId': self.device})
 
-            response = requests.post('https://spclient.wg.spotify.com/device-auth/v1/refresh', headers=headers, data=request_body)
+            response = requests.post(
+                'https://spclient.wg.spotify.com/device-auth/v1/refresh',
+                headers=headers,
+                data=request_body
+            )
+
             json_resp = response.json()
             self.send_message({
                 "type": TYPE_ADD_USER,
@@ -86,13 +92,13 @@ class SpotifyController(BaseController):
         if self.access_token is None or self.expires is None:
             raise ValueError("access_token and expires cannot be empty")
 
-        def callback():
+        def callback(*_):
             """Callback function"""
             self.send_message({"type": TYPE_GET_INFO, "payload": {
                 "remoteName": self.castDevice.cast_info.friendly_name,
                 "deviceID": self.getSpotifyDeviceID(),
                 "deviceAPI_isGroup": False,
-            },})
+            }, })
 
         self.device = None
         self.credential_error = False

--- a/custom_components/spotcast/spotify_controller.py
+++ b/custom_components/spotcast/spotify_controller.py
@@ -121,7 +121,8 @@ class SpotifyController(BaseController):
     def quick_play(self, **kwargs):
         """
         Launches the spotify controller and returns when it's ready.
-        To actually play media, another application using spotify connect is required.
+        To actually play media, another application using spotify
+        connect is required.
         """
         self.access_token = kwargs["access_token"]
         self.expires = kwargs["expires"]
@@ -132,4 +133,6 @@ class SpotifyController(BaseController):
         """
         Retrieve the Spotify deviceID from provided chromecast info
         """
-        return hashlib.md5(self.castDevice.cast_info.friendly_name.encode()).hexdigest()
+        return hashlib.md5(
+            self.castDevice.cast_info.friendly_name.encode()
+        ).hexdigest()


### PR DESCRIPTION
Took the change in #428 and also fixed issue from #429. Spotcast works fully in my dev environment currently running 2024.3.

At the same time I also updated a deprecated call to hass.weksocket_api to use the library directly. This was going to be deprecated in 2024.9