### PR TITLE
fix: do not go in transfer playback condition when asking for category

### DIFF
--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -271,6 +271,7 @@ def setup(hass: ha_core.HomeAssistant, config: collections.OrderedDict) -> bool:
                             episodeName,
                             audiobookName,
                             genreName,
+                            category, 
                         ],
                     )
                 )


### PR DESCRIPTION
When asking for a category with some call like : 
```yaml
action: spotcast.start
data:
  category: 0JQ5DAqbMKFI3pNLtYMD9S
  spotify_device_id: xxxxxxxxxxxxxxxxxxxxxxx
```

the part of code in `start_casting` which check for player transfer did not check if category was empty, hence result of above call was only a transfer (if needed), but category is never changed.