### PR TITLE
Verify device id even if provided in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ The spotcast custom component creates a service called 'spotcast.start' in Home 
 
 where:
 
-* `spotify_device_id` is the device ID of the Spotify Connect device
-* `device_name` is the friendly name of the chromecast device
+* `spotify_device_id` is the device ID of the Spotify Connect device. It can be used with `device_name` when the Spotify Connect name differs from the Chromecast name.
+* `device_name` is the friendly name of the Chromecast device
 * `uri` is the Spotify uri, supports all uris including track (limit to one track)
 * `search` is a search query to resolve into a uri. This parameter will be overlooked if a uri is provided
 * `category` let spotify pick a random playlist inside a given [category](https://developer.spotify.com/console/get-browse-categories/)

--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -251,11 +251,10 @@ def setup(hass: ha_core.HomeAssistant, config: collections.OrderedDict) -> bool:
             uri[1] = uri[1].lower()
             uri = ":".join(uri)
 
-        # first, rely on spotify id given in config otherwise get one
-        if not spotify_device_id:
-            spotify_device_id = spotcast_controller.get_spotify_device_id(
-                account, spotify_device_id, device_name, entity_id
-            )
+        # verify spotify id given in config or get one
+        spotify_device_id = spotcast_controller.get_spotify_device_id(
+            account, spotify_device_id, device_name, entity_id
+        )
 
         if (
             is_empty_str(uri)


### PR DESCRIPTION
If `spotify_device_id` is provided in the config, you may still need to launch an app on Chromecast first to wake it up and make it available in the device list.

## Why `spotify_device_id` may be necessary

When Google Home devices are combined into a speaker pair, the Chromecast device name may be different from the Spotify device name. In that case, in `device_name`, you will want to use the friendly name of the Chromecast device. However, a device with that name won't be found in the list of Spotify devices, and you'll encounter an error. But if you add `spotify_device_id`, the Chromecast won't need to be woken up.

## Other changes in this PR
* Fixed several typing mistakes
* Formatted the edited parts of the code according to Python guidelines
* Removed duplicated code

I would also like to set up some basic CI to check formatting, run black, isort, codespell, and flake8. https://github.com/leikoilja/ha-google-home/ which I maintain can be a good example. Would you support such changes?