### PR TITLE
Declare spotipy as a dependency

### DIFF
--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -12,11 +12,11 @@
     "dependencies": [
         "spotify"
     ],
-    "requirements": [
-        "spotipy==2.23.0"
-    ],
     "documentation": "https://github.com/fondberg/spotcast",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/fondberg/spotcast/issues",
+    "requirements": [
+        "spotipy==2.23.0"
+    ],
     "version": "v3.9.0"
 }

--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -10,7 +10,8 @@
         "@fcusson"
     ],
     "dependencies": [
-        "spotify"
+        "spotify",
+        "spotipy==2.23.0"
     ],
     "documentation": "https://github.com/fondberg/spotcast",
     "iot_class": "cloud_polling",

--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -10,7 +10,9 @@
         "@fcusson"
     ],
     "dependencies": [
-        "spotify",
+        "spotify"
+    ],
+    "requirements": [
         "spotipy==2.23.0"
     ],
     "documentation": "https://github.com/fondberg/spotcast",


### PR DESCRIPTION
HA core has removed the dependency on spotipy in 2024.11 To keep the integration working this adds it back as a dependency. We might want to consider in the future using aiospotify. See here: https://github.com/home-assistant/core/pull/127728