### PR TITLE
Dealing with dissapear track causing error.

### DIFF
--- a/custom_components/spotcast/helpers.py
+++ b/custom_components/spotcast/helpers.py
@@ -349,7 +349,7 @@ def search_tracks(
 def add_tracks_to_queue(
     spotify_client: spotipy.Spotify, tracks: list = [], limit: int = 20
 ):
-    filtered = list(filter(lambda x: x and x["type"] == "track", tracks))
+    filtered = list(filter(lambda x: isinstance(x, dict) and x.get("type") == "track", tracks))
 
     if len(filtered) == 0:
         _LOGGER.debug("Cannot add ZERO tracks to the queue!")

--- a/custom_components/spotcast/helpers.py
+++ b/custom_components/spotcast/helpers.py
@@ -349,7 +349,7 @@ def search_tracks(
 def add_tracks_to_queue(
     spotify_client: spotipy.Spotify, tracks: list = [], limit: int = 20
 ):
-    filtered = list(filter(lambda x: x["type"] == "track", tracks))
+    filtered = list(filter(lambda x: x and x["type"] == "track", tracks))
 
     if len(filtered) == 0:
         _LOGGER.debug("Cannot add ZERO tracks to the queue!")


### PR DESCRIPTION
In some scenarios, if a track is banned, deleted, or disappears, the playlist will contain an empty track (None). This error occurs as a result but can be easily fixed.
Error code:
```
  File "/config/custom_components/spotcast/__init__.py", line 360, in start_casting
    add_tracks_to_queue(client, searchResults[1:])
  File "/config/custom_components/spotcast/helpers.py", line 353, in add_tracks_to_queue
    filtered = list(filter(lambda x: x["type"] == "track", tracks))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/spotcast/helpers.py", line 353, in <lambda>
    filtered = list(filter(lambda x: x["type"] == "track", tracks))
                                     ~^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```