### PR TITLE
fix: Spotify Desktop API rate limiting and resilience improvements

### DIFF
--- a/custom_components/spotcast/spotify/account.py
+++ b/custom_components/spotcast/spotify/account.py
@@ -749,9 +749,8 @@ class SpotifyAccount:
                 [uri],
             )
             return response[0] or {}
-        except SpotifyException:
-            # audio-features endpoint may be deprecated or restricted
-            LOGGER.debug("Could not fetch audio features for %s", uri)
+        except SpotifyException as exc:
+            LOGGER.warning("Could not fetch audio features for %s: %s", uri, exc.msg)
             return {}
 
     async def async_playlists_count(self) -> int:
@@ -880,12 +879,13 @@ class SpotifyAccount:
 
             try:
                 await actions[key](value, device_id)
-            except SpotifyException:
+            except SpotifyException as exc:
                 LOGGER.warning(
-                    "Could not apply %s=%s to device %s",
+                    "Could not apply %s=%s to device %s: %s",
                     key,
                     value,
                     device_id,
+                    exc.msg,
                 )
 
     async def async_play_media(

--- a/custom_components/spotcast/spotify/account.py
+++ b/custom_components/spotcast/spotify/account.py
@@ -878,7 +878,15 @@ class SpotifyAccount:
             if key not in actions:
                 continue
 
-            await actions[key](value, device_id)
+            try:
+                await actions[key](value, device_id)
+            except Exception:  # pylint: disable=W0718
+                LOGGER.warning(
+                    "Could not apply %s=%s to device %s",
+                    key,
+                    value,
+                    device_id,
+                )
 
     async def async_play_media(
         self,

--- a/custom_components/spotcast/spotify/account.py
+++ b/custom_components/spotcast/spotify/account.py
@@ -110,6 +110,7 @@ class SpotifyAccount:
         "playlist-read-private",
         "playlist-read-collaborative",
         "user-library-read",
+        "user-library-modify",
         "user-top-read",
         "user-read-playback-position",
         "user-read-recently-played",
@@ -527,7 +528,7 @@ class SpotifyAccount:
         )
 
         return await self._async_pager(
-            self.apis["private"].current_user_saved_episodes,
+            self.apis["public"].current_user_saved_episodes,
             appends=[self.country],
             max_items=limit,
         )
@@ -546,7 +547,7 @@ class SpotifyAccount:
         LOGGER.debug("Getting track information for `%s`", uri)
 
         result = await self.hass.async_add_executor_job(
-            self.apis["private"].track, uri, self.country
+            self.apis["public"].track, uri, self.country
         )
 
         return result
@@ -589,7 +590,7 @@ class SpotifyAccount:
         album_id = self._id_from_uri(uri)
 
         result = await self.hass.async_add_executor_job(
-            self.apis["private"].album,
+            self.apis["public"].album,
             album_id,
             self.country,
         )
@@ -609,7 +610,7 @@ class SpotifyAccount:
         LOGGER.debug("Fetching Top Tracks for artist `%s`", uri)
 
         result = await self.hass.async_add_executor_job(
-            self.apis["private"].artist_top_tracks,
+            self.apis["public"].artist_top_tracks,
             uri,
             self.country,
         )
@@ -624,7 +625,7 @@ class SpotifyAccount:
         playlist_id = self._id_from_uri(uri)
 
         result = await self._async_pager(
-            function=self.apis["private"].playlist_tracks,
+            function=self.apis["public"].playlist_tracks,
             prepends=[playlist_id, None],
             appends=[self.country],
         )
@@ -655,7 +656,7 @@ class SpotifyAccount:
         LOGGER.debug("Fetching episodes from show `%s`", uri)
 
         result = await self._async_pager(
-            function=self.apis["private"].show_episodes,
+            function=self.apis["public"].show_episodes,
             prepends=[uri],
             appends=[self.country],
             max_items=limit,
@@ -669,7 +670,7 @@ class SpotifyAccount:
         LOGGER.debug("Fetching information from episode `%s`")
 
         result = await self.hass.async_add_executor_job(
-            self.apis["private"].episode,
+            self.apis["public"].episode,
             uri,
             self.country,
         )
@@ -695,7 +696,7 @@ class SpotifyAccount:
             if force or dataset.is_expired():
                 LOGGER.debug("Refreshing playback state dataset")
                 data = await self.hass.async_add_executor_job(
-                    self.apis["private"].current_playback,
+                    self.apis["public"].current_playback,
                     self.country,
                     "episode",
                 )
@@ -743,7 +744,7 @@ class SpotifyAccount:
             return {}
 
         response = await self.hass.async_add_executor_job(
-            self.apis["private"].audio_features,
+            self.apis["public"].audio_features,
             [uri],
         )
 
@@ -754,7 +755,7 @@ class SpotifyAccount:
         await self.async_ensure_tokens_valid()
 
         return await self._async_get_count(
-            self.apis["private"].current_user_playlists
+            self.apis["public"].current_user_playlists
         )
 
     async def async_playlists(
@@ -773,7 +774,7 @@ class SpotifyAccount:
                 LOGGER.debug("Refreshing playlists dataset")
 
                 playlists = await self._async_pager(
-                    self.apis["private"].current_user_playlists,
+                    self.apis["public"].current_user_playlists,
                     max_items=max_items,
                 )
 
@@ -804,7 +805,7 @@ class SpotifyAccount:
         )
 
         search_result = await self.hass.async_add_executor_job(
-            self.apis["private"].search,
+            self.apis["public"].search,
             query.query_string,
             limit,
             0,
@@ -907,7 +908,7 @@ class SpotifyAccount:
             LOGGER.info("transfering playback to device `%s`", device_id)
             try:
                 await self.hass.async_add_executor_job(
-                    self.apis["private"].transfer_playback,
+                    self.apis["public"].transfer_playback,
                     device_id,
                     True,
                 )
@@ -931,7 +932,7 @@ class SpotifyAccount:
 
         try:
             await self.hass.async_add_executor_job(
-                self.apis["private"].start_playback,
+                self.apis["public"].start_playback,
                 device_id,
                 context_uri,
                 uris,
@@ -960,7 +961,7 @@ class SpotifyAccount:
         )
 
         await self.hass.async_add_executor_job(
-            self.apis["private"].shuffle,
+            self.apis["public"].shuffle,
             shuffle,
             device_id,
         )
@@ -984,7 +985,7 @@ class SpotifyAccount:
                 LOGGER.debug("Refreshing liked songs dataset")
 
                 liked_songs = await self._async_pager(
-                    self.apis["private"].current_user_saved_tracks,
+                    self.apis["public"].current_user_saved_tracks,
                 )
 
                 dataset.update(liked_songs)
@@ -1005,7 +1006,7 @@ class SpotifyAccount:
             LOGGER.debug("Expired liked_songs dataset after adding new likes")
 
             await self.hass.async_add_executor_job(
-                self.apis["private"].current_user_saved_tracks_add,
+                self.apis["public"].current_user_saved_tracks_add,
                 uris,
             )
 
@@ -1027,7 +1028,7 @@ class SpotifyAccount:
         )
 
         await self.hass.async_add_executor_job(
-            self.apis["private"].repeat,
+            self.apis["public"].repeat,
             state,
             device_id,
         )
@@ -1048,7 +1049,7 @@ class SpotifyAccount:
         LOGGER.info("Setting volume to %d%% for device `%s`", volume, device_id)
 
         await self.hass.async_add_executor_job(
-            self.apis["private"].volume,
+            self.apis["public"].volume,
             volume,
             device_id,
         )
@@ -1069,7 +1070,7 @@ class SpotifyAccount:
                 LOGGER.debug("Refreshing Browse Categories dataset")
 
                 categories = await self._async_pager(
-                    self.apis["private"].categories,
+                    self.apis["public"].categories,
                     prepends=[self.country, None],
                     sub_layer="categories",
                     max_items=limit,
@@ -1105,7 +1106,7 @@ class SpotifyAccount:
         )
 
         playlists = await self._async_pager(
-            self.apis["private"].category_playlists,
+            self.apis["public"].category_playlists,
             prepends=[category_id, self.country],
             sub_layer="playlists",
             max_items=limit,
@@ -1177,7 +1178,7 @@ class SpotifyAccount:
             "offset": offset,
         }
 
-        return self.apis["private"]._get(url, params)
+        return self.apis["public"]._get(url, params)
 
     async def _async_get_count(
         self,
@@ -1293,7 +1294,7 @@ class SpotifyAccount:
 
         try:
             await self.hass.async_add_executor_job(
-                self.apis["private"].add_to_queue,
+                self.apis["public"].add_to_queue,
                 uri,
                 device_id,
             )

--- a/custom_components/spotcast/spotify/account.py
+++ b/custom_components/spotcast/spotify/account.py
@@ -749,7 +749,7 @@ class SpotifyAccount:
                 [uri],
             )
             return response[0] or {}
-        except Exception:  # pylint: disable=W0718
+        except SpotifyException:
             # audio-features endpoint may be deprecated or restricted
             LOGGER.debug("Could not fetch audio features for %s", uri)
             return {}
@@ -880,7 +880,7 @@ class SpotifyAccount:
 
             try:
                 await actions[key](value, device_id)
-            except Exception:  # pylint: disable=W0718
+            except SpotifyException:
                 LOGGER.warning(
                     "Could not apply %s=%s to device %s",
                     key,

--- a/custom_components/spotcast/spotify/account.py
+++ b/custom_components/spotcast/spotify/account.py
@@ -743,12 +743,16 @@ class SpotifyAccount:
         if uri is None or not uri.startswith("spotify:track:"):
             return {}
 
-        response = await self.hass.async_add_executor_job(
-            self.apis["public"].audio_features,
-            [uri],
-        )
-
-        return response[0] or {}
+        try:
+            response = await self.hass.async_add_executor_job(
+                self.apis["public"].audio_features,
+                [uri],
+            )
+            return response[0] or {}
+        except Exception:  # pylint: disable=W0718
+            # audio-features endpoint may be deprecated or restricted
+            LOGGER.debug("Could not fetch audio features for %s", uri)
+            return {}
 
     async def async_playlists_count(self) -> int:
         """Returns the number of user playlist for an account."""

--- a/test/config_flow_classes/config_flow_handler/test_async_oauth_create_entry.py
+++ b/test/config_flow_classes/config_flow_handler/test_async_oauth_create_entry.py
@@ -124,21 +124,19 @@ class TestAllDataProvided(IsolatedAsyncioTestCase):
 
         await self.handler.async_oauth_create_entry({})
 
-    def test_spotify_created_with_proper_tokens(self):
+    def test_spotify_created_with_public_token(self):
+        # Only public token is validated during setup to avoid rate limits
         try:
-            self.mocks["spotify_constructor"].assert_has_calls([
-                call(auth="foo"),
-                call(auth="bar"),
-            ])
+            self.mocks["spotify_constructor"].assert_called_once_with(auth="foo")
         except AssertionError as exc:
             self.fail(exc)
 
-    def test_profiles_from_both_sessions_retrieved(self):
+    def test_profile_from_public_session_retrieved(self):
+        # Only public session profile is retrieved during setup
         try:
-            self.mocks["hass"].async_add_executor_job.assert_has_calls([
-                call(self.mocks["spotify_sessions"][0].current_user),
-                call(self.mocks["spotify_sessions"][1].current_user),
-            ])
+            self.mocks["hass"].async_add_executor_job.assert_called_once_with(
+                self.mocks["spotify_sessions"][0].current_user,
+            )
         except AssertionError as exc:
             self.fail(exc)
 
@@ -213,54 +211,8 @@ class TestProfileRefreshError(IsolatedAsyncioTestCase):
         self.assertIs(self.result, self.mocks["abort"].return_value)
 
 
-class TestUnmatchedProfile(IsolatedAsyncioTestCase):
-
-    @patch.object(SpotcastFlowHandler, "async_abort", new_callable=MagicMock)
-    @patch(f"{TEST_MODULE}.Spotify", new_callable=MagicMock)
-    async def asyncSetUp(self, mock_spotify: MagicMock, mock_abort: MagicMock):
-
-        mock_spotify.return_value = MagicMock(spec=Spotify)
-
-        self.mocks = {
-            "hass": MagicMock(spec=HomeAssistant),
-            "spotify": mock_spotify.return_value,
-            "abort": mock_abort,
-        }
-
-        self.handler = SpotcastFlowHandler()
-        self.handler.hass = self.mocks["hass"]
-        self.handler.data = {
-            "external_api": {
-                "token": {
-                    "access_token": "foo",
-                },
-            },
-            "desktop_api": {
-                "token": {
-                    "access_token": "bar",
-                },
-            },
-        }
-
-        self.mocks["hass"].async_add_executor_job = AsyncMock()
-        self.mocks["hass"].async_add_executor_job\
-            .side_effect = [
-                {"id": "foo"},
-                {"id": "bar"},
-        ]
-
-        self.result = await self.handler.async_oauth_create_entry({})
-
-    def test_process_aborted(self):
-        try:
-            self.mocks["abort"].assert_called_with(
-                reason="public_private_accounts_mismatch",
-            )
-        except AssertionError as exc:
-            self.fail(exc)
-
-    def test_returns_abort_flow_result(self):
-        self.assertIs(self.result, self.mocks["abort"].return_value)
+# TestUnmatchedProfile removed - we no longer validate both public and private
+# profiles during setup to avoid rate limit issues. Only public token is validated.
 
 
 class TestReauthMismatch(IsolatedAsyncioTestCase):

--- a/test/spotify/account/test_async_add_to_queue.py
+++ b/test/spotify/account/test_async_add_to_queue.py
@@ -63,7 +63,7 @@ class TestAddToQueueJob(IsolatedAsyncioTestCase):
     def test_proper_executor_job_called(self):
         try:
             self.mocks["hass"].async_add_executor_job.assert_called_with(
-                self.account.apis["private"].add_to_queue,
+                self.account.apis["public"].add_to_queue,
                 "spotify:dummy:uri",
                 None,
             )

--- a/test/spotify/account/test_async_apply_extras.py
+++ b/test/spotify/account/test_async_apply_extras.py
@@ -4,6 +4,8 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock, patch, AsyncMock
 from time import time
 
+from spotipy import SpotifyException
+
 from custom_components.spotcast.spotify.account import (
     SpotifyAccount,
     PublicSession,
@@ -139,3 +141,60 @@ class TestSkippedExtras(IsolatedAsyncioTestCase):
                 mock.assert_not_called()
             except AssertionError:
                 self.fail()
+
+
+class TestApplyExtrasWithException(IsolatedAsyncioTestCase):
+    """Test that SpotifyException in extras doesn't crash the call."""
+
+    @patch(f"{TEST_MODULE}.Store", spec=Store, new_callable=MagicMock)
+    @patch(f"{TEST_MODULE}.Spotify", new_callable=MagicMock)
+    async def asyncSetUp(
+            self,
+            mock_spotify: MagicMock,
+            mock_store: MagicMock,
+    ):
+
+        self.mocks = {
+            "internal": MagicMock(spec=PrivateSession),
+            "external": MagicMock(spec=PublicSession),
+            "hass": MagicMock(spec=HomeAssistant),
+        }
+        self.mocks["hass"].loop = MagicMock()
+
+        self.account = SpotifyAccount(
+            entry_id="12345",
+            hass=self.mocks["hass"],
+            public_session=self.mocks["external"],
+            private_session=self.mocks["internal"],
+            is_default=True
+        )
+
+        self.account.async_ensure_tokens_valid = AsyncMock()
+
+        self.account._datasets["profile"].expires_at = time() + 9999
+        self.account._datasets["profile"]._data = {"name": "Dummy"}
+
+        # Make volume raise, but shuffle and repeat succeed
+        self.account.async_set_volume = AsyncMock(
+            side_effect=SpotifyException(403, -1, "Forbidden")
+        )
+        self.account.async_shuffle = AsyncMock()
+        self.account.async_repeat = AsyncMock()
+
+        # Should not raise despite volume failing
+        await self.account.async_apply_extras(
+            "foo",
+            {"volume": 80, "shuffle": True, "repeat": "context"}
+        )
+
+    def test_shuffle_still_called_despite_volume_error(self):
+        try:
+            self.account.async_shuffle.assert_called_with(True, "foo")
+        except AssertionError:
+            self.fail()
+
+    def test_repeat_still_called_despite_volume_error(self):
+        try:
+            self.account.async_repeat.assert_called_with("context", "foo")
+        except AssertionError:
+            self.fail()

--- a/test/spotify/account/test_async_categories.py
+++ b/test/spotify/account/test_async_categories.py
@@ -113,7 +113,7 @@ class TestDatasetExpired(IsolatedAsyncioTestCase):
     def test_new_profile_was_not_fetched(self):
         try:
             self.account._async_pager.assert_called_with(
-                self.account.apis["private"].categories,
+                self.account.apis["public"].categories,
                 prepends=[None, None],
                 sub_layer="categories",
                 max_items=None,

--- a/test/spotify/account/test_async_category_playlists.py
+++ b/test/spotify/account/test_async_category_playlists.py
@@ -53,7 +53,7 @@ class TestPlaylistRetrieval(IsolatedAsyncioTestCase):
     def test_pager_called_with_proper_arguments(self):
         try:
             self.mocks["pager"].assert_called_with(
-                self.account.apis["private"].category_playlists,
+                self.account.apis["public"].category_playlists,
                 prepends=["12345", "CA"],
                 sub_layer="playlists",
                 max_items=None,

--- a/test/spotify/account/test_async_get_album.py
+++ b/test/spotify/account/test_async_get_album.py
@@ -124,7 +124,7 @@ class TestPlayslistRetrieval(IsolatedAsyncioTestCase):
     def test_proper_call_to__executor(self):
         try:
             self.mocks["hass"].async_add_executor_job.assert_called_with(
-                self.account.apis["private"].album,
+                self.account.apis["public"].album,
                 "foo",
                 "CA",
             )

--- a/test/spotify/account/test_async_get_artist_top_tracks.py
+++ b/test/spotify/account/test_async_get_artist_top_tracks.py
@@ -62,7 +62,7 @@ class TestPlayslistRetrieval(IsolatedAsyncioTestCase):
     def test_proper_call_to__executor(self):
         try:
             self.mocks["hass"].async_add_executor_job.assert_called_with(
-                self.account.apis["private"].artist_top_tracks,
+                self.account.apis["public"].artist_top_tracks,
                 "spotify:artist:foo",
                 "CA",
             )

--- a/test/spotify/account/test_async_get_count.py
+++ b/test/spotify/account/test_async_get_count.py
@@ -48,10 +48,10 @@ class TestPagingApiEndpoint(IsolatedAsyncioTestCase):
             private_session=self.mocks["internal"],
             public_session=self.mocks["external"],
         )
-        self.account.apis["private"].dummy_endpoint = MagicMock()
+        self.account.apis["public"].dummy_endpoint = MagicMock()
 
         self.result = await self.account._async_get_count(
-            self.account.apis["private"].dummy_endpoint
+            self.account.apis["public"].dummy_endpoint
         )
 
     def test_proper_result_retrieved(self):
@@ -97,10 +97,10 @@ class TestSubLayeredPager(IsolatedAsyncioTestCase):
             is_default=True
         )
 
-        self.account.apis["private"].dummy_endpoint = MagicMock()
+        self.account.apis["public"].dummy_endpoint = MagicMock()
 
         self.result = await self.account._async_get_count(
-            self.account.apis["private"].dummy_endpoint,
+            self.account.apis["public"].dummy_endpoint,
             sub_layer="foo"
         )
 

--- a/test/spotify/account/test_async_get_episode.py
+++ b/test/spotify/account/test_async_get_episode.py
@@ -135,7 +135,7 @@ class TestEpisodeRetrieval(IsolatedAsyncioTestCase):
     def test_proper_call_to_executor(self):
         try:
             self.mocks["hass"].async_add_executor_job.assert_called_with(
-                self.account.apis["private"].episode,
+                self.account.apis["public"].episode,
                 "spotify:episode:foo",
                 "CA",
             )

--- a/test/spotify/account/test_async_get_playlist.py
+++ b/test/spotify/account/test_async_get_playlist.py
@@ -97,7 +97,7 @@ class TestPlayslistRetrieval(IsolatedAsyncioTestCase):
     def test_proper_call_to__executor(self):
         try:
             self.mocks["hass"].async_add_executor_job.assert_called_with(
-                self.account.apis["private"].playlist,
+                self.account.apis["public"].playlist,
                 "foo",
                 None,
                 "CA",

--- a/test/spotify/account/test_async_get_playlist_tracks.py
+++ b/test/spotify/account/test_async_get_playlist_tracks.py
@@ -55,7 +55,7 @@ class TestPlaylistTrackRetrieval(IsolatedAsyncioTestCase):
     def test_pager_properly_called(self):
         try:
             self.account._async_pager.assert_called_with(
-                function=self.account.apis["private"].playlist_tracks,
+                function=self.account.apis["public"].playlist_tracks,
                 prepends=["foo", None],
                 appends=["CA"]
             )

--- a/test/spotify/account/test_async_get_show_episodes.py
+++ b/test/spotify/account/test_async_get_show_episodes.py
@@ -55,7 +55,7 @@ class TestShowEpisodesRetrieval(IsolatedAsyncioTestCase):
     def test_pager_properly_called(self):
         try:
             self.account._async_pager.assert_called_with(
-                function=self.account.apis["private"].show_episodes,
+                function=self.account.apis["public"].show_episodes,
                 prepends=["spotify:show:foo"],
                 appends=["CA"],
                 max_items=None,

--- a/test/spotify/account/test_async_get_track.py
+++ b/test/spotify/account/test_async_get_track.py
@@ -130,7 +130,7 @@ class TestSongRetrieval(IsolatedAsyncioTestCase):
     def test_executor_job_properly_called(self):
         try:
             self.mocks["hass"].async_add_executor_job.assert_called_with(
-                self.account.apis["private"].track,
+                self.account.apis["public"].track,
                 "spotify:track:55mJleti2WfWEFNFcBduhc",
                 "CA"
             )

--- a/test/spotify/account/test_async_like_media.py
+++ b/test/spotify/account/test_async_like_media.py
@@ -60,7 +60,7 @@ class TestLikeSongs(IsolatedAsyncioTestCase):
     def test_executor_properly_called(self):
         try:
             self.mocks["hass"].async_add_executor_job.assert_called_with(
-                self.account.apis["private"].current_user_saved_tracks_add,
+                self.account.apis["public"].current_user_saved_tracks_add,
                 ["foo", "bar", "baz"]
             )
         except AssertionError:

--- a/test/spotify/account/test_async_liked_songs.py
+++ b/test/spotify/account/test_async_liked_songs.py
@@ -125,7 +125,7 @@ class TestDatasetExpired(IsolatedAsyncioTestCase):
     def test_new_profile_was_fetched(self):
         try:
             self.mocks["pager"].assert_called_with(
-                self.account.apis["private"].current_user_saved_tracks
+                self.account.apis["public"].current_user_saved_tracks
             )
         except AssertionError:
             self.fail()
@@ -189,7 +189,7 @@ class TestForcerefresh(IsolatedAsyncioTestCase):
     def test_new_profile_was_fetched(self):
         try:
             self.mocks["pager"].assert_called_with(
-                self.account.apis["private"].current_user_saved_tracks
+                self.account.apis["public"].current_user_saved_tracks
             )
         except AssertionError:
             self.fail()

--- a/test/spotify/account/test_async_pager.py
+++ b/test/spotify/account/test_async_pager.py
@@ -48,10 +48,10 @@ class TestPagingApiEndpoint(IsolatedAsyncioTestCase):
             private_session=self.mocks["internal"],
             public_session=self.mocks["external"],
         )
-        self.account.apis["private"].dummy_endpoint = MagicMock()
+        self.account.apis["public"].dummy_endpoint = MagicMock()
 
         self.result = await self.account._async_pager(
-            self.account.apis["private"].dummy_endpoint
+            self.account.apis["public"].dummy_endpoint
         )
 
     def test_proper_result_retrieved(self):
@@ -104,10 +104,10 @@ class TestPagingWithLimit(IsolatedAsyncioTestCase):
             private_session=self.mocks["internal"],
             is_default=True
         )
-        self.account.apis["private"].dummy_endpoint = MagicMock()
+        self.account.apis["public"].dummy_endpoint = MagicMock()
 
         self.result = await self.account._async_pager(
-            self.account.apis["private"].dummy_endpoint,
+            self.account.apis["public"].dummy_endpoint,
             max_items=3,
         )
 
@@ -160,10 +160,10 @@ class TestSubLayeredPager(IsolatedAsyncioTestCase):
             is_default=True
         )
 
-        self.account.apis["private"].dummy_endpoint = MagicMock()
+        self.account.apis["public"].dummy_endpoint = MagicMock()
 
         self.result = await self.account._async_pager(
-            self.account.apis["private"].dummy_endpoint,
+            self.account.apis["public"].dummy_endpoint,
             sub_layer="foo"
         )
 

--- a/test/spotify/account/test_async_play_media.py
+++ b/test/spotify/account/test_async_play_media.py
@@ -65,7 +65,7 @@ class TestMediaPlayback(IsolatedAsyncioTestCase):
     def test_play_media_was_called(self):
         try:
             self.mocks["hass"].async_add_executor_job.assert_called_with(
-                self.account.apis["private"].start_playback,
+                self.account.apis["public"].start_playback,
                 "foo",
                 "spotify:dummy:uri",
                 None,
@@ -120,7 +120,7 @@ class TestEmptyContext(IsolatedAsyncioTestCase):
     def test_play_media_was_called(self):
         try:
             self.mocks["hass"].async_add_executor_job.assert_called_with(
-                self.account.apis["private"].transfer_playback,
+                self.account.apis["public"].transfer_playback,
                 "foo",
                 True
             )
@@ -175,7 +175,7 @@ class TestFailedTransfer(IsolatedAsyncioTestCase):
     def test_play_media_was_called(self):
         try:
             self.mocks["hass"].async_add_executor_job.assert_called_with(
-                self.account.apis["private"].transfer_playback,
+                self.account.apis["public"].transfer_playback,
                 "foo",
                 True
             )
@@ -232,7 +232,7 @@ class TestMediaPlaybackWithExtras(IsolatedAsyncioTestCase):
     def test_play_media_was_called(self):
         try:
             self.mocks["hass"].async_add_executor_job.assert_called_with(
-                self.account.apis["private"].start_playback,
+                self.account.apis["public"].start_playback,
                 "foo",
                 "spotify:dummy:uri",
                 None,

--- a/test/spotify/account/test_async_playlists.py
+++ b/test/spotify/account/test_async_playlists.py
@@ -118,7 +118,7 @@ class TestDatasetExpired(IsolatedAsyncioTestCase):
     def test_new_profile_was_fetched(self):
         try:
             self.mocks["pager"].assert_called_with(
-                self.account.apis["private"].current_user_playlists,
+                self.account.apis["public"].current_user_playlists,
                 max_items=None
             )
         except AssertionError:
@@ -176,7 +176,7 @@ class TestForceRefresh(IsolatedAsyncioTestCase):
     def test_new_profile_was_fetched(self):
         try:
             self.mocks["pager"].assert_called_with(
-                self.account.apis["private"].current_user_playlists,
+                self.account.apis["public"].current_user_playlists,
                 max_items=None,
             )
         except AssertionError:

--- a/test/spotify/account/test_async_saved_episodes.py
+++ b/test/spotify/account/test_async_saved_episodes.py
@@ -67,7 +67,7 @@ class TestDatasetFresh(IsolatedAsyncioTestCase):
     def test_pager_properly_called(self):
         try:
             self.account._async_pager.assert_called_with(
-                self.account.apis["private"].current_user_saved_episodes,
+                self.account.apis["public"].current_user_saved_episodes,
                 appends=["CA"],
                 max_items=None
             )

--- a/test/spotify/account/test_async_track_features.py
+++ b/test/spotify/account/test_async_track_features.py
@@ -3,6 +3,8 @@
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock, patch, AsyncMock
 
+from spotipy import SpotifyException
+
 from custom_components.spotcast.spotify.account import (
     SpotifyAccount,
     PrivateSession,
@@ -74,7 +76,7 @@ class TestTrackFeature(IsolatedAsyncioTestCase):
     def test_properly_call_executor(self):
         try:
             self.mocks["hass"].async_add_executor_job.assert_called_with(
-                self.account.apis["private"].audio_features,
+                self.account.apis["public"].audio_features,
                 ["spotify:track:foo"],
             )
         except AssertionError:
@@ -117,3 +119,35 @@ class TestEpisodesFeature(IsolatedAsyncioTestCase):
             self.mocks["hass"].async_add_executor_job.assert_not_called()
         except AssertionError:
             self.fail()
+
+
+class TestTrackFeatureWithException(IsolatedAsyncioTestCase):
+    """Test that SpotifyException is handled gracefully."""
+
+    @patch(f"{TEST_MODULE}.Store", spec=Store, new_callable=MagicMock)
+    @patch(f"{TEST_MODULE}.Spotify", spec=Spotify, new_callable=MagicMock)
+    async def asyncSetUp(self, mock_spotify: MagicMock, mock_store: MagicMock):
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "public": MagicMock(spec=PublicSession),
+            "private": MagicMock(spec=PrivateSession),
+        }
+
+        self.account = SpotifyAccount(
+            entry_id="12345",
+            hass=self.mocks["hass"],
+            public_session=self.mocks["public"],
+            private_session=self.mocks["private"],
+        )
+
+        self.mocks["hass"].async_add_executor_job = AsyncMock(
+            side_effect=SpotifyException(403, -1, "Forbidden")
+        )
+
+        self.result = await self.account.async_track_features(
+            "spotify:track:foo"
+        )
+
+    def test_returns_empty_dict_on_exception(self):
+        self.assertEqual(self.result, {})

--- a/test/spotify/account/test_fetch_view.py
+++ b/test/spotify/account/test_fetch_view.py
@@ -8,6 +8,7 @@ from custom_components.spotcast.spotify.account import (
     HomeAssistant,
     PublicSession,
     PrivateSession,
+    Spotify,
     Store,
 )
 
@@ -17,7 +18,8 @@ from test.spotify.account import TEST_MODULE
 class TestPlaylistRetrieval(TestCase):
 
     @patch(f"{TEST_MODULE}.Store", spec=Store, new_callable=MagicMock)
-    def setUp(self, mock_store: MagicMock):
+    @patch(f"{TEST_MODULE}.Spotify", spec=Spotify, new_callable=MagicMock)
+    def setUp(self, mock_spotify: MagicMock, mock_store: MagicMock):
 
         self.mocks = {
             "hass": MagicMock(spec=HomeAssistant),
@@ -37,14 +39,14 @@ class TestPlaylistRetrieval(TestCase):
             "country": "CA"
         }
 
-        self.account.apis["private"] = MagicMock()
-        self.account.apis["private"]._get.return_value = ["foo", "bar", "baz"]
+        self.account.apis["public"] = MagicMock()
+        self.account.apis["public"]._get.return_value = ["foo", "bar", "baz"]
 
         self.result = self.account._fetch_view("content/foo", "fr")
 
     def test_proper_call_to_get(self):
         try:
-            self.account.apis["private"]._get.assert_called_with(
+            self.account.apis["public"]._get.assert_called_with(
                 "content/foo",
                 {
                     "content_limit": 25,


### PR DESCRIPTION
## Summary

This PR fixes the authentication issues reported in #593 where Spotify started blocking the Desktop client_id (`65b708073fc0480ea92a077233ca87bd`) on `api.spotify.com` endpoints around December 22-23, 2025.

## Root Cause Analysis

Spotify now returns **fake 429 (rate limit) responses** for the Desktop client_id on all `api.spotify.com` endpoints. These are not real rate limits - they're permanent blocks disguised as rate limits. The `Retry-After` header resets but requests continue to fail.

**Key findings:**
- The Desktop client_id is NOT blocked entirely - it still works for `spclient.wg.spotify.com` (Chromecast authentication)
- The Public OAuth token (from Home Assistant's Spotify integration) works without rate limits on `api.spotify.com`
- Both tokens are still needed: Public for API calls, Desktop for Chromecast wake-up

## Changes

### 1. Skip Desktop token validation during setup (`config_flow_handler.py`)
- Only validate the Public token during config flow
- Desktop token is obtained via OAuth so we know it's valid
- Prevents setup failures due to rate limiting

### 2. Use Public token for all `api.spotify.com` calls (`account.py`)
- Changed all `self.apis["private"]` → `self.apis["public"]` for Spotipy API calls
- Added `user-library-modify` scope to support `async_like_media`
- Desktop token still used for Chromecast auth via `get_token("private")` in `spotify_controller.py`

### 3. Handle deprecated `audio-features` endpoint gracefully
- The `/audio-features/` endpoint now returns 403 Forbidden
- Wrapped in try/except to prevent crashes during playback transfers
- Audio features are just metadata - not critical for playback

### 4. Make extras (shuffle, repeat, volume) fail gracefully
- Non-critical operations now log warnings instead of crashing
- Playback transfer completes even if Spotify breaks these endpoints

## Token Usage After This Fix

| Endpoint | Token Used |
|----------|------------|
| `api.spotify.com/*` | Public (no rate limits) |
| `spclient.wg.spotify.com/device-auth/v1/refresh` | Desktop (Chromecast auth) |

## Testing

Manually verified complete Chromecast playback transfer flow:
1. ✅ Wake Chromecast with Desktop token → `spclient.wg.spotify.com` returns 200
2. ✅ Get devices with Public token → `api.spotify.com` returns 200
3. ✅ Transfer playback with Public token → `api.spotify.com` returns 204
4. ✅ Set repeat mode with Public token → `api.spotify.com` returns 200

## Breaking Changes

- **Existing users may need to re-authenticate** to get the new `user-library-modify` scope on their Public token (only affects the "like media" feature)

## Related Issues

Fixes #593

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)