### PR TITLE
fix: filter None items from async_search results

### DIFF
--- a/custom_components/spotcast/spotify/account.py
+++ b/custom_components/spotcast/spotify/account.py
@@ -820,7 +820,9 @@ class SpotifyAccount:
 
         for item_type in query.item_types:
             key = f"{item_type}s"
-            result[key] = search_result[key]["items"]
+            result[key] = [
+                i for i in (search_result[key]["items"] or []) if i is not None
+            ]
 
         return result
 

--- a/test/spotify/account/test_async_search.py
+++ b/test/spotify/account/test_async_search.py
@@ -55,3 +55,47 @@ class TestSearchQuery(IsolatedAsyncioTestCase):
 
     def test_proper_result_provided(self):
         self.assertEqual(self.result, {"artists": ["foo", "bar", "baz"]})
+
+
+class TestSearchQueryNullItems(IsolatedAsyncioTestCase):
+    """Tests that async_search handles None and null items from the Spotify API."""
+
+    @patch(f"{TEST_MODULE}.Store", spec=Store, new_callable=MagicMock)
+    @patch.object(SpotifyAccount, "_async_pager")
+    async def asyncSetUp(self, mock_pager: AsyncMock, mock_store: MagicMock):
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "external": MagicMock(spec=PublicSession),
+            "internal": MagicMock(spec=PrivateSession),
+        }
+
+        self.account = SpotifyAccount(
+            entry_id="12345",
+            hass=self.mocks["hass"],
+            public_session=self.mocks["external"],
+            private_session=self.mocks["internal"],
+        )
+        self.account._datasets["profile"].expires_at = time() + 999
+        self.account._datasets["profile"]._data = {"country": "CA"}
+
+        self.query = SearchQuery(
+            search="foo",
+            item_types="artist",
+        )
+
+    async def _run_search(self, api_return_value: dict) -> dict:
+        self.mocks["hass"].async_add_executor_job = AsyncMock(
+            return_value=api_return_value
+        )
+        return await self.account.async_search(self.query)
+
+    async def test_null_items_list_returns_empty(self):
+        """Spotify API sometimes returns None for items when a category has no results."""
+        result = await self._run_search({"artists": {"items": None}})
+        self.assertEqual(result, {"artists": []})
+
+    async def test_items_containing_none_values_are_filtered(self):
+        """Spotify API sometimes returns [None] in items for certain result types."""
+        result = await self._run_search({"artists": {"items": [None, "foo", None, "bar"]}})
+        self.assertEqual(result, {"artists": ["foo", "bar"]})


### PR DESCRIPTION
## NOTICE:
The stuff below was written by Claude Sonnet 4.6 and not me. It went through and fixed something for me today. If you don't want to review this, I totally understand and you can close it straight away. I figured I would offer it up.

## Problem

The Spotify API occasionally returns `None` for the `items` list, or a list containing `None` values, for certain item types. This happens when searching with `item_types` that the current Spotify Developer app scope doesn't fully support — the API returns the key but with a null items value rather than an empty list.

Previously, this caused a `TypeError` in `get_best_candidate` when iterating over the results:

```
TypeError: 'NoneType' object is not subscriptable
```

## Fix

Filter `None` values from `items` at the point of collection in `async_search`, handling both cases:
- `items` is `None` → treat as empty list
- `items` is a list containing `None` entries → filter them out

## Tests

Added two new test cases to `test_async_search.py`:
- `test_null_items_list_returns_empty` — covers `{"items": None}` API response
- `test_items_containing_none_values_are_filtered` — covers `{"items": [None, "foo", None]}` API response