### PR TITLE
Fix random playlist start when Spotify returns items instead of tracks

### DIFF
--- a/custom_components/spotcast/services/play_media.py
+++ b/custom_components/spotcast/services/play_media.py
@@ -190,7 +190,14 @@ async def async_random_index(account: SpotifyAccount, uri: str) -> int:
         count = album["total_tracks"]
     elif uri.startswith("spotify:playlist:"):
         playlist = await account.async_get_playlist(uri)
-        count = playlist["tracks"]["total"]
+        if "tracks" in playlist:
+            count = playlist["tracks"]["total"]
+        elif "items" in playlist:
+            count = playlist["items"]["total"]
+        else:
+            raise ServiceValidationError(
+                f"Could not get track count for {uri}"
+            )
     elif uri == account.liked_songs_uri:
         count = await account.async_liked_songs_count()
     else:

--- a/test/services/play_media/test_async_random_index.py
+++ b/test/services/play_media/test_async_random_index.py
@@ -75,6 +75,38 @@ class TestPlaylistRandInt(IsolatedAsyncioTestCase):
             self.fail()
 
 
+class TestPlaylistItemsRandInt(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.randint", new_callable=MagicMock)
+    async def asyncSetUp(self, mock_random: MagicMock):
+
+        mock_random.return_value = 7
+
+        self.mocks = {
+            "account": MagicMock(spec=SpotifyAccount)
+        }
+
+        self.mocks["account"].async_get_playlist = AsyncMock()
+        self.mocks["account"].async_get_playlist.return_value = {
+            "items": {
+                "total": 53
+            }
+        }
+        self.resut = await async_random_index(
+            self.mocks["account"],
+            "spotify:playlist:foo",
+        )
+
+    def test_received_expected_index(self):
+        self.assertEqual(self.resut, 7)
+
+    def test_get_playlist_called(self):
+        try:
+            self.mocks["account"].async_get_playlist.assert_called()
+        except AssertionError:
+            self.fail()
+
+
 class TestUserLikedSongs(IsolatedAsyncioTestCase):
 
     @patch(f"{TEST_MODULE}.randint", new_callable=MagicMock)


### PR DESCRIPTION
## Summary
- Fix `KeyError: 'tracks'` when calling `spotcast.play_media` with `data.random: true` on a playlist
- Support Spotify's updated playlist API response where track paging is returned under top-level `items` instead of `tracks`
- Add unit test coverage for the new `items.total` response shape

## Problem
Spotify's `GET /v1/playlists/{id}` response now exposes track paging under top-level `items` (with `items.total`) instead of `tracks`. The existing `async_random_index` logic only handled the legacy `tracks.total` shape, causing automations using `random: true` to fail before playback started.

## Test plan
- [x] Added `TestPlaylistItemsRandInt` for the new response shape
- [ ] Existing unit tests pass in CI
- [x] Verified manually in Home Assistant with a real playlist and `random: true`


Made with [Cursor](https://cursor.com)