### PR TITLE
Gracefully handle Spotify 404 on editorial/algorithmic playlists

### DIFF
--- a/custom_components/spotcast/services/play_media.py
+++ b/custom_components/spotcast/services/play_media.py
@@ -19,7 +19,10 @@ from custom_components.spotcast.media_player.exceptions import (
 )
 from custom_components.spotcast.spotify import SpotifyAccount
 from custom_components.spotcast.utils import get_account_entry
-from custom_components.spotcast.spotify.utils import url_to_uri
+from custom_components.spotcast.spotify.utils import (
+    url_to_uri,
+    suppress_playlist_404_logs,
+)
 from custom_components.spotcast.media_player.utils import (
     async_media_player_from_id,
 )
@@ -30,6 +33,12 @@ from custom_components.spotcast.services.utils import (
 )
 
 LOGGER = getLogger(__name__)
+
+# Spotify 404s on its own editorial/algorithmic playlists, so their track
+# count is unavailable. Such playlists are always well above this many
+# tracks, so a pseudo-random start within the first N keeps `random`
+# meaningful without risking an out-of-range offset (see #570).
+_RANDOM_FALLBACK_ITEMS = 25
 
 PLAY_MEDIA_SCHEMA = vol.Schema(
     {
@@ -191,7 +200,8 @@ async def async_random_index(account: SpotifyAccount, uri: str) -> int:
         count = album["total_tracks"]
     elif uri.startswith("spotify:playlist:"):
         try:
-            playlist = await account.async_get_playlist(uri)
+            with suppress_playlist_404_logs():
+                playlist = await account.async_get_playlist(uri)
             count = playlist["tracks"]["total"]
         except SpotifyException as exc:
             if exc.http_status != 404:
@@ -199,11 +209,12 @@ async def async_random_index(account: SpotifyAccount, uri: str) -> int:
             LOGGER.warning(
                 "Spotify returned 404 for playlist `%s` (likely a Spotify "
                 "editorial/algorithmic playlist no longer exposed through "
-                "the Web API). Starting at the first track instead of a "
-                "random offset.",
+                "the Web API). Using a pseudo-random start offset within "
+                "the first %d tracks.",
                 uri,
+                _RANDOM_FALLBACK_ITEMS,
             )
-            return 0
+            return randint(0, _RANDOM_FALLBACK_ITEMS - 1)
     elif uri == account.liked_songs_uri:
         count = await account.async_liked_songs_count()
     else:

--- a/custom_components/spotcast/services/play_media.py
+++ b/custom_components/spotcast/services/play_media.py
@@ -11,6 +11,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 import voluptuous as vol
+from spotipy import SpotifyException
 
 
 from custom_components.spotcast.media_player.exceptions import (
@@ -189,8 +190,20 @@ async def async_random_index(account: SpotifyAccount, uri: str) -> int:
         album = await account.async_get_album(uri)
         count = album["total_tracks"]
     elif uri.startswith("spotify:playlist:"):
-        playlist = await account.async_get_playlist(uri)
-        count = playlist["tracks"]["total"]
+        try:
+            playlist = await account.async_get_playlist(uri)
+            count = playlist["tracks"]["total"]
+        except SpotifyException as exc:
+            if exc.http_status != 404:
+                raise
+            LOGGER.warning(
+                "Spotify returned 404 for playlist `%s` (likely a Spotify "
+                "editorial/algorithmic playlist no longer exposed through "
+                "the Web API). Starting at the first track instead of a "
+                "random offset.",
+                uri,
+            )
+            return 0
     elif uri == account.liked_songs_uri:
         count = await account.async_liked_songs_count()
     else:

--- a/custom_components/spotcast/services/transfer_playback.py
+++ b/custom_components/spotcast/services/transfer_playback.py
@@ -11,6 +11,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.util.read_only_dict import ReadOnlyDict
 from homeassistant.exceptions import ServiceValidationError
 import voluptuous as vol
+from spotipy import SpotifyException
 
 
 from custom_components.spotcast.spotify.account import SpotifyAccount
@@ -142,8 +143,21 @@ async def async_rebuild_playback(
         tracks = []
 
         if context_type == "playlist":
-            tracks = await account.async_get_playlist_tracks(context_uri)
-            tracks = [x["track"]["uri"] for x in tracks]
+            try:
+                playlist_tracks = await account.async_get_playlist_tracks(
+                    context_uri
+                )
+                tracks = [x["track"]["uri"] for x in playlist_tracks]
+            except SpotifyException as exc:
+                if exc.http_status != 404:
+                    raise
+                LOGGER.warning(
+                    "Spotify returned 404 for playlist `%s` (likely a "
+                    "Spotify editorial/algorithmic playlist no longer "
+                    "exposed through the Web API). Rebuilding playback "
+                    "from the first track.",
+                    context_uri,
+                )
         else:
             tracks = await account.async_liked_songs()
 

--- a/custom_components/spotcast/services/transfer_playback.py
+++ b/custom_components/spotcast/services/transfer_playback.py
@@ -15,6 +15,7 @@ from spotipy import SpotifyException
 
 
 from custom_components.spotcast.spotify.account import SpotifyAccount
+from custom_components.spotcast.spotify.utils import suppress_playlist_404_logs
 from custom_components.spotcast.services.play_media import (
     async_play_media,
     async_track_index,
@@ -140,26 +141,9 @@ async def async_rebuild_playback(
     # finding the current uri in the list
     elif context_type in ("playlist", "collection"):
 
-        tracks = []
-
-        if context_type == "playlist":
-            try:
-                playlist_tracks = await account.async_get_playlist_tracks(
-                    context_uri
-                )
-                tracks = [x["track"]["uri"] for x in playlist_tracks]
-            except SpotifyException as exc:
-                if exc.http_status != 404:
-                    raise
-                LOGGER.warning(
-                    "Spotify returned 404 for playlist `%s` (likely a "
-                    "Spotify editorial/algorithmic playlist no longer "
-                    "exposed through the Web API). Rebuilding playback "
-                    "from the first track.",
-                    context_uri,
-                )
-        else:
-            tracks = await account.async_liked_songs()
+        tracks = await _async_context_track_uris(
+            account, context_type, context_uri
+        )
 
         try:
             track_index = tracks.index(current_item["uri"])
@@ -172,3 +156,33 @@ async def async_rebuild_playback(
         call_data["data"]["offset"] = track_index
 
     return call_data
+
+
+async def _async_context_track_uris(
+    account: SpotifyAccount,
+    context_type: str,
+    context_uri: str,
+) -> list[str]:
+    """Returns the track uris of a playlist or collection context.
+
+    Spotify 404s on its own editorial/algorithmic playlists, so treat
+    that as an empty track list and let the caller rebuild playback from
+    the first track. See issues #570 and #599.
+    """
+    if context_type != "playlist":
+        return await account.async_liked_songs()
+
+    try:
+        with suppress_playlist_404_logs():
+            tracks = await account.async_get_playlist_tracks(context_uri)
+        return [x["track"]["uri"] for x in tracks]
+    except SpotifyException as exc:
+        if exc.http_status != 404:
+            raise
+        LOGGER.warning(
+            "Spotify returned 404 for playlist `%s` (likely a Spotify "
+            "editorial/algorithmic playlist no longer exposed through the "
+            "Web API). Rebuilding playback from the first track.",
+            context_uri,
+        )
+        return []

--- a/custom_components/spotcast/spotify/utils.py
+++ b/custom_components/spotcast/spotify/utils.py
@@ -1,5 +1,10 @@
 """Utility functions for interacting with Spotify"""
 
+import logging
+from contextlib import contextmanager
+
+_SPOTIPY_LOGGER = logging.getLogger("spotipy.client")
+
 
 def select_image_url(images: list[dict]) -> str:
     """Returns the highest resolution image available according to the
@@ -57,3 +62,28 @@ def url_to_uri(url: str) -> str:
     uri = ":".join(elems)
 
     return uri
+
+
+@contextmanager
+def suppress_playlist_404_logs():
+    """Silence spotipy's ERROR log for an expected playlist 404.
+
+    Spotify returns 404 for its own editorial/algorithmic playlists
+    (`37i9...`) when their content is requested through the Web API.
+    spotipy logs the HTTP error itself (`spotipy/client.py`) *before*
+    raising `SpotifyException`, so a `try/except` around the call cannot
+    prevent the noisy ERROR line. Spotcast expects and handles this 404,
+    so drop only that record for the duration of the call. Any other
+    spotipy error (including non-playlist 404s) still logs normally.
+    """
+
+    def _drop_expected_404(record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        return not ("returned 404" in message and "playlists/" in message)
+
+    _SPOTIPY_LOGGER.addFilter(_drop_expected_404)
+
+    try:
+        yield
+    finally:
+        _SPOTIPY_LOGGER.removeFilter(_drop_expected_404)

--- a/docs/services/play_media.md
+++ b/docs/services/play_media.md
@@ -43,3 +43,5 @@ Set of additional settings to apply when starting the playback. The available op
 | `repeat`   | `track \| context \| off` | `null`  | The repeat mode is kept the same if `null`                                                                                                  |
 | `shuffle`  | `bool`                    | `null`  | Sets the playback to shuffle if `True`. Is kept unchanged if `null`.                                                                        |
 | `random`   | `bool`                    | `False` | Sets the context playback to a random song of the context. Only available for albums, playlists and custom contexts |
+
+> **Spotify editorial/algorithmic playlists** (the `spotify:playlist:37i9…` IDs — Daily Mix, Discover Weekly, Release Radar, song radios, etc.): Spotify no longer serves these playlists' contents through the Web API, so `random` cannot read the real track count. For them it falls back to a random start within the **first 25 tracks** (emitted as a log warning). Regular playlists are unaffected.

--- a/docs/services/transfer_playback.md
+++ b/docs/services/transfer_playback.md
@@ -37,3 +37,5 @@ Set of additional settings to apply when starting the playback. The available op
 | `volume`   | `int`, `range 0-100`      | `null`  | The percentage (as an integer of the percentage value) to start plaback at. Volume is kept unchanged if `null`                              |
 | `repeat`   | `track \| context \| off` | `null`  | The repeat mode is kept the same if `null`                                                                                                  |
 | `shuffle`  | `bool`                    | `null`  | Sets the playback to shuffle if `True`. Is kept unchanged if `null`.                                                                        |
+
+> **Spotify editorial/algorithmic playlists** (the `spotify:playlist:37i9…` IDs): Spotify no longer serves these playlists' contents through the Web API, so the exact current track can't be located when rebuilding playback — it restarts from the **first track** of the context.

--- a/test/services/play_media/test_async_random_index.py
+++ b/test/services/play_media/test_async_random_index.py
@@ -9,6 +9,7 @@ from custom_components.spotcast.services.play_media import (
     async_random_index,
     SpotifyAccount,
     ServiceValidationError,
+    _RANDOM_FALLBACK_ITEMS,
 )
 
 TEST_MODULE = "custom_components.spotcast.services.play_media"
@@ -123,13 +124,18 @@ class TestInvalidContextUri(IsolatedAsyncioTestCase):
 
 class TestPlaylistNotFound(IsolatedAsyncioTestCase):
     """Spotify 404s on its own editorial/algorithmic playlists when
-    fetched through the Web API. Random start must degrade to the first
-    track instead of raising. See issues #570 and #599."""
+    fetched through the Web API. Random start must fall back to a pseudo-
+    random offset within the first `_RANDOM_FALLBACK_ITEMS` tracks instead
+    of raising. See issues #570 and #599."""
 
-    async def asyncSetUp(self):
+    @patch(f"{TEST_MODULE}.randint", new_callable=MagicMock)
+    async def asyncSetUp(self, mock_random: MagicMock):
+
+        mock_random.return_value = 7
 
         self.mocks = {
-            "account": MagicMock(spec=SpotifyAccount)
+            "account": MagicMock(spec=SpotifyAccount),
+            "random": mock_random,
         }
 
         self.mocks["account"].async_get_playlist = AsyncMock(
@@ -141,8 +147,16 @@ class TestPlaylistNotFound(IsolatedAsyncioTestCase):
             "spotify:playlist:37i9dQZF1DX4sWSpwq3LiO",
         )
 
-    def test_degrades_to_first_track(self):
-        self.assertEqual(self.resut, 0)
+    def test_returns_pseudo_random_offset(self):
+        self.assertEqual(self.resut, 7)
+
+    def test_offset_bounded_to_fallback_range(self):
+        try:
+            self.mocks["random"].assert_called_once_with(
+                0, _RANDOM_FALLBACK_ITEMS - 1
+            )
+        except AssertionError as exc:
+            self.fail(exc)
 
 
 class TestPlaylistOtherSpotifyError(IsolatedAsyncioTestCase):

--- a/test/services/play_media/test_async_random_index.py
+++ b/test/services/play_media/test_async_random_index.py
@@ -3,6 +3,8 @@
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock, AsyncMock, patch
 
+from spotipy import SpotifyException
+
 from custom_components.spotcast.services.play_media import (
     async_random_index,
     SpotifyAccount,
@@ -116,4 +118,48 @@ class TestInvalidContextUri(IsolatedAsyncioTestCase):
             self.resut = await async_random_index(
                 self.mocks["account"],
                 "spotify:track:foo",
+            )
+
+
+class TestPlaylistNotFound(IsolatedAsyncioTestCase):
+    """Spotify 404s on its own editorial/algorithmic playlists when
+    fetched through the Web API. Random start must degrade to the first
+    track instead of raising. See issues #570 and #599."""
+
+    async def asyncSetUp(self):
+
+        self.mocks = {
+            "account": MagicMock(spec=SpotifyAccount)
+        }
+
+        self.mocks["account"].async_get_playlist = AsyncMock(
+            side_effect=SpotifyException(404, -1, "Resource not found")
+        )
+
+        self.resut = await async_random_index(
+            self.mocks["account"],
+            "spotify:playlist:37i9dQZF1DX4sWSpwq3LiO",
+        )
+
+    def test_degrades_to_first_track(self):
+        self.assertEqual(self.resut, 0)
+
+
+class TestPlaylistOtherSpotifyError(IsolatedAsyncioTestCase):
+    """Non-404 Spotify errors must still propagate."""
+
+    async def test_error_reraised(self):
+
+        self.mocks = {
+            "account": MagicMock(spec=SpotifyAccount)
+        }
+
+        self.mocks["account"].async_get_playlist = AsyncMock(
+            side_effect=SpotifyException(500, -1, "Server Error")
+        )
+
+        with self.assertRaises(SpotifyException):
+            await async_random_index(
+                self.mocks["account"],
+                "spotify:playlist:foo",
             )

--- a/test/services/transfer_playback/test_async_rebuild_playback.py
+++ b/test/services/transfer_playback/test_async_rebuild_playback.py
@@ -3,6 +3,8 @@
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock, AsyncMock, patch
 
+from spotipy import SpotifyException
+
 from custom_components.spotcast.services.transfer_playback import (
     async_rebuild_playback,
     SpotifyAccount,
@@ -673,3 +675,62 @@ class TestArtistContext(IsolatedAsyncioTestCase):
 
     def test_offset_removed(self):
         self.assertIsNone(self.result["data"]["offset"])
+
+
+class TestPlaylistContextNotFound(IsolatedAsyncioTestCase):
+    """Spotify 404s on its own editorial/algorithmic playlists. The
+    playback rebuild must degrade to the first track (offset 0) instead
+    of raising. See issues #570 and #599."""
+
+    @patch(f"{TEST_MODULE}.async_track_index")
+    async def asyncSetUp(self, mock_index: AsyncMock):
+
+        self.mocks = {
+            "account": MagicMock(spec=SpotifyAccount),
+            "index": mock_index,
+        }
+
+        self.mocks["account"].async_last_playback_state = AsyncMock()
+        self.mocks["account"].async_last_playback_state.return_value = {
+            "repeat_state": "context",
+            "shuffle_state": True,
+            "context": {
+                "uri": "spotify:playlist:37i9dQZF1DX4sWSpwq3LiO",
+                "type": "playlist"
+            },
+            "item": {
+                "album": {
+                    "uri": "spotify:album:baz"
+                },
+                "uri": "spotify:track:bar"
+            }
+        }
+
+        self.mocks["account"].async_get_playlist_tracks = AsyncMock(
+            side_effect=SpotifyException(404, -1, "Resource not found")
+        )
+
+        self.call_data = {
+            "media_player": {
+                "entity_id": [
+                    "media_player.foo"
+                ]
+            },
+            "data": {
+                "position": 5
+            }
+        }
+
+        self.result = await async_rebuild_playback(
+            self.call_data,
+            self.mocks["account"],
+        )
+
+    def test_degrades_to_first_track(self):
+        self.assertEqual(self.result["data"]["offset"], 0)
+
+    def test_playlist_uri_kept(self):
+        self.assertEqual(
+            self.result["spotify_uri"],
+            "spotify:playlist:37i9dQZF1DX4sWSpwq3LiO",
+        )

--- a/test/spotify/utils/test_suppress_playlist_404_logs.py
+++ b/test/spotify/utils/test_suppress_playlist_404_logs.py
@@ -1,0 +1,71 @@
+"""Module to test the suppress_playlist_404_logs context manager"""
+
+import logging
+from unittest import TestCase
+
+from custom_components.spotcast.spotify.utils import suppress_playlist_404_logs
+
+PLAYLIST_404 = (
+    "HTTP Error for GET to "
+    "https://api.spotify.com/v1/playlists/37i9dQZF1DX1tuUiirhaT3 "
+    "with Params: {} returned 404 due to Resource not found"
+)
+
+
+class _CollectingHandler(logging.Handler):
+    """Captures emitted records so the test can assert on them."""
+
+    def __init__(self):
+        super().__init__()
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+class TestSuppressPlaylist404Logs(TestCase):
+
+    def setUp(self):
+        self.logger = logging.getLogger("spotipy.client")
+        self.handler = _CollectingHandler()
+        self.logger.addHandler(self.handler)
+        self._previous_level = self.logger.level
+        self.logger.setLevel(logging.DEBUG)
+
+    def tearDown(self):
+        self.logger.removeHandler(self.handler)
+        self.logger.setLevel(self._previous_level)
+
+    def test_playlist_404_is_dropped(self):
+        with suppress_playlist_404_logs():
+            self.logger.error(PLAYLIST_404)
+
+        self.assertEqual(self.handler.records, [])
+
+    def test_non_404_error_passes(self):
+        with suppress_playlist_404_logs():
+            self.logger.error(
+                "HTTP Error for GET to "
+                "https://api.spotify.com/v1/playlists/foo "
+                "with Params: {} returned 500 due to Server Error"
+            )
+
+        self.assertEqual(len(self.handler.records), 1)
+
+    def test_non_playlist_404_passes(self):
+        with suppress_playlist_404_logs():
+            self.logger.error(
+                "HTTP Error for GET to "
+                "https://api.spotify.com/v1/albums/foo "
+                "with Params: {} returned 404 due to Resource not found"
+            )
+
+        self.assertEqual(len(self.handler.records), 1)
+
+    def test_filter_removed_after_context(self):
+        with suppress_playlist_404_logs():
+            pass
+
+        self.logger.error(PLAYLIST_404)
+
+        self.assertEqual(len(self.handler.records), 1)


### PR DESCRIPTION
## Summary

Spotify no longer serves the contents of its own **editorial / algorithmic playlists** (the `37i9…` IDs — Daily Mix, Discover Weekly, Release Radar, song radios, editorial playlists) through the Web API, returning **404** for both `GET /v1/playlists/{id}` and `GET /v1/playlists/{id}/tracks` (part of the [2024-11-27 Web API changes](https://developer.spotify.com/blog/2024-11-27-changes-to-the-web-api)). Any Spotcast feature that has to *read* the playlist therefore hard-fails:

- **`play_media` with `random: true`** — `async_random_index()` fetches the playlist to compute the track count → 404 → the whole service call raises.
- **`transfer_playback` on an idle player** — `async_rebuild_playback()` fetches the playlist tracks to locate the current offset → 404 → the transfer raises.

This PR catches that 404 in both paths and degrades gracefully instead of raising.

Fixes #570. Also resolves the `transfer_playback` failure reported in #599.

## Changes

- **`play_media` / `async_random_index`** — on a playlist 404, fall back to a **pseudo-random offset within the first 25 tracks** so `random` still varies the starting track instead of failing (the approach @fcusson suggested in #570). Editorial/algorithmic playlists — the only ones that 404 — are always well above this, so the offset stays in range. Non-404 Spotify errors still propagate.
- **`transfer_playback` / `async_rebuild_playback`** — on a playlist 404, rebuild from the first track (the exact song can't be located, so start the context over). The playlist/collection track lookup is extracted into a small helper to keep the function readable.
- **`suppress_playlist_404_logs`** (new, in `spotify/utils.py`) — spotipy logs the HTTP error itself in `spotipy/client.py` *before* raising `SpotifyException`, so a `try/except` cannot prevent the noisy `ERROR` line (the same limitation discussed for audio-features in #600). This scoped context manager drops **only** the expected `404 … playlists/…` record for the duration of the call; every other spotipy error — including non-playlist 404s — still logs. Without it, users see a misleading `ERROR` on every editorial-playlist call and keep re-filing #570/#599.

## Notes / scope

- Only the **404** is swallowed; any other Spotify error still raises and logs as before.
- The `random` fallback is a heuristic by necessity: the track count of a 404ing playlist can't be read, so a bounded pseudo-random offset is the pragmatic choice. 25 sits safely below the smallest algorithmic playlists (~30 tracks).
- Independent of #610 (no file overlap); the two can merge in either order.

## Testing

- New / updated unit tests: pseudo-random fallback + non-404 re-raise (`test_async_random_index`), transfer 404 → first track (`test_async_rebuild_playback`), and the log filter (`test_suppress_playlist_404_logs`).
- Full suite green (637 tests) on Python 3.13; pylint 9.90/10.
- Manually verified in Home Assistant against `spotify:playlist:37i9dQZF1DX1tuUiirhaT3` with `random: true`:
  - **Before:** `404 … /v1/playlists/37i9…` traceback, service call fails.
  - **After:** playback starts on a random track, no spotipy `ERROR`, a single `WARNING … pseudo-random start offset within the first 25 tracks`.

## References

- Spotify Web API deprecation: https://developer.spotify.com/blog/2024-11-27-changes-to-the-web-api
- #570 — original report (editorial-playlist 404 on `play_media` + random) and @fcusson's pseudo-random-offset suggestion
- #599 — `transfer_playback` 404 on an idle editorial-playlist context
- #593 — related outage discussion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
