### PR TITLE
Remove unused imports (dead-code cleanup)

### DIFF
--- a/custom_components/spotcast/media_player/chromecast_player.py
+++ b/custom_components/spotcast/media_player/chromecast_player.py
@@ -1,14 +1,9 @@
 """Module containing the chromecast media player implementation"""
 
 from logging import getLogger
-from uuid import UUID
 from hashlib import md5
 
-from pychromecast import (
-    Chromecast as ParentChromecast,
-    HostServiceInfo,
-    CastInfo,
-)
+from pychromecast import Chromecast as ParentChromecast
 
 import pychromecast  # pylint: disable=unused-import
 

--- a/custom_components/spotcast/sensor/abstract_sensor.py
+++ b/custom_components/spotcast/sensor/abstract_sensor.py
@@ -4,7 +4,6 @@ from logging import getLogger
 
 from homeassistant.components.sensor import (
     SensorStateClass,
-    SensorEntityDescription,
     EntityCategory,
     SensorEntity,
     SensorDeviceClass,

--- a/custom_components/spotcast/sessions/private_session.py
+++ b/custom_components/spotcast/sessions/private_session.py
@@ -12,7 +12,6 @@ from asyncio import Lock
 from random import randrange
 from aiohttp import ClientSession
 from aiohttp.client_exceptions import (
-    ContentTypeError,
     ClientOSError,
     ClientResponseError,
 )


### PR DESCRIPTION
## Summary

Removes five unused imports. No behaviour change.

| File | Removed |
|---|---|
| `media_player/chromecast_player.py` | `UUID`, `CastInfo`, `HostServiceInfo` |
| `sensor/abstract_sensor.py` | `SensorEntityDescription` |
| `sessions/private_session.py` | `ContentTypeError` |

A few other imports that look unused are actually re-exported (e.g. `SensorDeviceClass`,
`UnknownMessageError`) and were left in place.

## Testing

- Full unit suite green: **628 tests, OK** (Python 3.13).
- `pylint custom_components/spotcast`: **9.54/10**.

## Scope

Independent of #610 and #611 — no file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
