### PR TITLE
Sanitize device names into valid entity IDs

### DIFF
--- a/custom_components/spotcast/media_player/spotify_player.py
+++ b/custom_components/spotcast/media_player/spotify_player.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_UNAVAILABLE
 )
+from homeassistant.util import slugify
 
 from custom_components.spotcast.media_player import MediaPlayer
 from custom_components.spotcast.spotify import SpotifyAccount
@@ -113,14 +114,6 @@ class SpotifyDevice(MediaPlayer, MediaPlayerEntity):
     def _define_entity_id(self):
         """Define the entity ID based on the account profile"""
 
-        removals = "()"
-
-        name: str = self.device_data["name"]
-
-        name = name.lower()
-        name = name.replace(" ", "_")
-
-        for char in removals:
-            name = name.replace(char, "")
+        name = slugify(self.device_data["name"])
 
         return f"media_player.{name}_{self._account.id}_spotcast"

--- a/test/media_player/spotify_device/test_define_entity_id.py
+++ b/test/media_player/spotify_device/test_define_entity_id.py
@@ -58,3 +58,53 @@ class TestComplexName(TestCase):
             self.device._define_entity_id(),
             "media_player.dummy_device_chrome_dummy_spotcast"
         )
+
+
+class TestNonAsciiName(TestCase):
+
+    def setUp(self):
+
+        self.mock_account = MagicMock(spec=SpotifyAccount)
+        self.mock_account.id = "dummy"
+        self.mock_account.name = "Dummy User"
+
+        self.device = SpotifyDevice(
+            self.mock_account,
+            {
+                "id": "12345",
+                "name": "Echo Dot Küche",
+                "type": "dummy",
+                "is_active": True,
+            }
+        )
+
+    def test_umlaut_transliterated(self):
+        self.assertEqual(
+            self.device._define_entity_id(),
+            "media_player.echo_dot_kuche_dummy_spotcast"
+        )
+
+
+class TestUmlautOnlyName(TestCase):
+
+    def setUp(self):
+
+        self.mock_account = MagicMock(spec=SpotifyAccount)
+        self.mock_account.id = "dummy"
+        self.mock_account.name = "Dummy User"
+
+        self.device = SpotifyDevice(
+            self.mock_account,
+            {
+                "id": "12345",
+                "name": "Überall",
+                "type": "dummy",
+                "is_active": True,
+            }
+        )
+
+    def test_umlaut_transliterated(self):
+        self.assertEqual(
+            self.device._define_entity_id(),
+            "media_player.uberall_dummy_spotcast"
+        )


### PR DESCRIPTION
## Summary

Spotify device names containing non-ASCII characters (e.g. German umlauts like `ü`, `ö`) leaked directly into the generated `media_player` entity ID, producing IDs that Home Assistant rejects as invalid:

> Detected that custom integration 'spotcast' sets an invalid entity ID: 'media_player.überall_5ykg7ebzlon2o9gg5jj5xirxe_spotcast'. In most cases, entities should not set entity_id, but if they do, it should be a valid entity ID. This will stop working in Home Assistant 2027.2.0

HA entity IDs must be ASCII (`^[a-z0-9_]+$`). The old `_define_entity_id` only lowercased the name, replaced spaces with underscores, and stripped parentheses — it never handled non-ASCII characters, so `Küche` → `küche` and `Überall` → `überall` passed straight through.

## Fix

Use Home Assistant's `homeassistant.util.slugify`, which transliterates non-ASCII to ASCII (`Küche` → `kuche`, `Überall` → `uberall`) and already handles lowercasing, separator normalisation, and stripping of illegal characters — making the manual block redundant.

Existing ASCII names produce identical output (`dummy_device` → `dummy_device`, `Dummy Device (Chrome)` → `dummy_device_chrome`), so current users' entity IDs are unchanged; only the previously-invalid umlaut IDs are corrected. `unique_id` is derived from the opaque Spotify device id, not the name, so it is unaffected and there is no entity migration.

## Tests

Added `TestNonAsciiName` (`Echo Dot Küche` → `media_player.echo_dot_kuche_dummy_spotcast`) and `TestUmlautOnlyName` (`Überall` → `media_player.uberall_dummy_spotcast`) to `test/media_player/spotify_device/test_define_entity_id.py`. Existing simple/complex name and constructor assertions still pass.

Fixes #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)