### PR TITLE
Handle None entries in Spotify search results

### DIFF
--- a/custom_components/spotcast/services/play_from_search.py
+++ b/custom_components/spotcast/services/play_from_search.py
@@ -7,6 +7,7 @@ Functions:
 from logging import getLogger
 
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.util.read_only_dict import ReadOnlyDict
 import voluptuous as vol
@@ -97,6 +98,12 @@ async def async_play_from_search(hass: HomeAssistant, call: ServiceCall):
             call_data.pop(key)
 
     best_candidate = get_best_candidate(search_term, search_result)
+
+    if best_candidate is None:
+        raise ServiceValidationError(
+            f"No search results found for `{search_term}`"
+        )
+
     items = search_result[best_candidate]
 
     context_uri = items[0]["uri"]

--- a/custom_components/spotcast/spotify/account.py
+++ b/custom_components/spotcast/spotify/account.py
@@ -820,7 +820,11 @@ class SpotifyAccount:
 
         for item_type in query.item_types:
             key = f"{item_type}s"
-            result[key] = search_result[key]["items"]
+            result[key] = [
+                item
+                for item in search_result[key]["items"]
+                if item is not None
+            ]
 
         return result
 

--- a/test/services/play_from_search/test_async_play_from_search.py
+++ b/test/services/play_from_search/test_async_play_from_search.py
@@ -4,6 +4,7 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock, AsyncMock, patch
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.exceptions import ServiceValidationError
 
 from custom_components.spotcast.services.play_from_search import (
     async_play_from_search,
@@ -61,3 +62,34 @@ class TestPlayFromSearch(IsolatedAsyncioTestCase):
             self.mocks["call"].data.get("spotify_uri"),
             "spotify:artist:foo",
         )
+
+
+class TestNoSearchResults(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.async_play_media")
+    @patch.object(SpotifyAccount, "async_from_config_entry")
+    @patch(f"{TEST_MODULE}.get_account_entry", new_callable=MagicMock)
+    async def test_raises_service_validation_error(
+        self,
+        mock_entry: MagicMock,
+        mock_account: AsyncMock,
+        mock_play: AsyncMock,
+    ):
+
+        mock_entry.return_value = MagicMock(spec=ConfigEntry)
+        mock_account.return_value = MagicMock(spec=SpotifyAccount)
+        mock_account.return_value.async_search = AsyncMock(return_value={
+            "artists": [],
+            "tracks": [],
+        })
+
+        call = MagicMock(spec=ServiceCall)
+        call.data = {
+            "search_term": "foo",
+            "item_types": ["track", "artist"],
+        }
+
+        with self.assertRaises(ServiceValidationError):
+            await async_play_from_search(MagicMock(spec=HomeAssistant), call)
+
+        mock_play.assert_not_called()

--- a/test/services/play_from_search/test_get_best_candidate.py
+++ b/test/services/play_from_search/test_get_best_candidate.py
@@ -47,3 +47,14 @@ class TestCandidateBasedOnType(TestCase):
 
     def test_proper_result_selected(self):
         self.assertEqual(self.result, "artists")
+
+
+class TestNoResults(TestCase):
+
+    def test_empty_search_result_returns_none(self):
+        self.assertIsNone(get_best_candidate("foo", {}))
+
+    def test_all_empty_categories_returns_none(self):
+        self.assertIsNone(
+            get_best_candidate("foo", {"artists": [], "albums": []})
+        )

--- a/test/spotify/account/test_async_search.py
+++ b/test/spotify/account/test_async_search.py
@@ -55,3 +55,42 @@ class TestSearchQuery(IsolatedAsyncioTestCase):
 
     def test_proper_result_provided(self):
         self.assertEqual(self.result, {"artists": ["foo", "bar", "baz"]})
+
+
+class TestSearchQueryWithNoneItems(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.Store", spec=Store, new_callable=MagicMock)
+    @patch.object(SpotifyAccount, "_async_pager")
+    async def asyncSetUp(self, mock_pager: AsyncMock, mock_store: MagicMock):
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "external": MagicMock(spec=PublicSession),
+            "internal": MagicMock(spec=PrivateSession),
+            "pager": mock_pager,
+        }
+
+        self.account = SpotifyAccount(
+            entry_id="12345",
+            hass=self.mocks["hass"],
+            public_session=self.mocks["external"],
+            private_session=self.mocks["internal"],
+        )
+        self.account._datasets["profile"].expires_at = time() + 999
+        self.account._datasets["profile"]._data = {
+            "country": "CA"
+        }
+
+        self.query = SearchQuery(
+            search="foo",
+            item_types="artist",
+        )
+
+        self.mocks["hass"].async_add_executor_job = AsyncMock(
+            return_value={"artists": {"items": ["foo", None, "bar"]}}
+        )
+
+        self.result = await self.account.async_search(self.query)
+
+    def test_none_items_are_stripped(self):
+        self.assertEqual(self.result, {"artists": ["foo", "bar"]})


### PR DESCRIPTION
## Summary

`spotcast.play_from_search` returns a 500 whenever Spotify's `/search` API includes a `null` entry in one of the `items` arrays (which it does for region-restricted / unavailable content):

```
File "play_from_search.py", line 141, in get_best_candidate
    candidate = items[0]["name"]
TypeError: 'NoneType' object is not subscriptable
```

**Root cause:** `SpotifyAccount.async_search` forwards the raw `items` lists verbatim (`result[key] = search_result[key]["items"]`), so any `None` element propagates to code that assumes every item is a well-formed dict.

## Changes

- **Strip `None` items at the source** in `async_search`, so no consumer ever sees them. This is the root-cause fix and also protects the websocket search handler (`websocket/search_handler.py`), which iterates `for item in results: item.get(...)` and had the same latent crash.
- **Raise a user-friendly `ServiceValidationError`** from `async_play_from_search` when the search yields no usable candidate, instead of the `KeyError`/500 that a `None` `best_candidate` produced on the empty-results path.
- **Regression tests** for the `None`-item filter, the empty-result return from `get_best_candidate`, and the raised `ServiceValidationError`.

## Testing

- Touched suites pass; full suite green (628 tests OK).
- No new pylint warnings.

Fixes #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)
