### PR TITLE
Add a 'Spotcast has moved' migration notice (v6.0.0-a17)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.0.0-a16
+current_version = 6.0.0-a17
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[^\d]*)(?P<build>\d+))?
 serialize = 

--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.const import Platform
 from homeassistant.helpers import entity_registry
+from homeassistant.helpers import issue_registry as ir
 
 from .const import DOMAIN
 from .services import ServiceHandler
@@ -27,7 +28,13 @@ from .spotify import SpotifyAccount
 from .sensor.abstract_entity import SpotcastEntity
 from .sensor.spotify_current_audio_features import SENSORS as AF_SENSORS
 
-__version__ = "6.0.0-a16"
+__version__ = "6.0.0-a17"
+
+MOVED_ISSUE_ID = "spotcast_moved"
+MOVED_LEARN_MORE_URL = (
+    "https://github.com/Mincka/spotcast"
+    "#coming-from-the-original-fondbergspotcast"
+)
 
 
 LOGGER = getLogger(__name__)
@@ -49,6 +56,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if updated_options != entry.options:
         hass.config_entries.async_update_entry(entry, options=updated_options)
+
+    # Spotcast has moved to Mincka/spotcast. Surface a one-time repair so
+    # users on this legacy fondberg/spotcast build know where to migrate.
+    # Created before token validation so it shows even when this abandoned
+    # build can no longer authenticate. The issue registry remembers the
+    # dismissed state, so this is safe to call on every setup.
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        MOVED_ISSUE_ID,
+        is_fixable=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key=MOVED_ISSUE_ID,
+        learn_more_url=MOVED_LEARN_MORE_URL,
+    )
 
     try:
         account = await SpotifyAccount.async_from_config_entry(

--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -20,5 +20,5 @@
         "spotifyaio>=0.8.8",
         "RapidFuzz>=3.10.1"
     ],
-    "version": "v6.0.0-a16"
+    "version": "v6.0.0-a17"
 }

--- a/custom_components/spotcast/strings.json
+++ b/custom_components/spotcast/strings.json
@@ -1,4 +1,10 @@
 {
+    "issues": {
+        "spotcast_moved": {
+            "title": "Spotcast has moved to a new repository",
+            "description": "Spotcast is now maintained at github.com/Mincka/spotcast. This copy, installed from the original fondberg/spotcast repository, is abandoned and no longer receives updates. Select **Learn more** for migration steps. Your accounts, tokens, entities and automations carry over untouched."
+        }
+    },
     "config": {
         "step": {
             "desktop_api": {

--- a/custom_components/spotcast/translations/en.json
+++ b/custom_components/spotcast/translations/en.json
@@ -1,4 +1,10 @@
 {
+    "issues": {
+        "spotcast_moved": {
+            "title": "Spotcast has moved to a new repository",
+            "description": "Spotcast is now maintained at github.com/Mincka/spotcast. This copy, installed from the original fondberg/spotcast repository, is abandoned and no longer receives updates. Select **Learn more** for migration steps. Your accounts, tokens, entities and automations carry over untouched."
+        }
+    },
     "config": {
         "step": {
             "desktop_api": {

--- a/custom_components/spotcast/translations/fr.json
+++ b/custom_components/spotcast/translations/fr.json
@@ -1,4 +1,10 @@
 {
+    "issues": {
+        "spotcast_moved": {
+            "title": "Spotcast a déménagé vers un nouveau dépôt",
+            "description": "Spotcast est désormais maintenu sur github.com/Mincka/spotcast. Cette copie, installée depuis le dépôt d'origine fondberg/spotcast, est abandonnée et ne reçoit plus de mises à jour. Sélectionnez **En savoir plus** pour les étapes de migration. Vos comptes, jetons, entités et automatisations sont conservés tels quels."
+        }
+    },
     "config": {
         "step": {
             "desktop_api": {

--- a/info.md
+++ b/info.md
@@ -6,6 +6,17 @@
 
 ------------------------------------------------------------------------------
 
+> **Spotcast has moved to [Mincka/spotcast](https://github.com/Mincka/spotcast)**
+>
+> This repository is abandoned and no longer maintained. This release only adds
+> this migration notice, so there is no need to install it. Switch to the
+> maintained repository instead; your accounts, tokens, entities and automations
+> carry over untouched.
+>
+> **Migration guide:** https://github.com/Mincka/spotcast#coming-from-the-original-fondbergspotcast
+
+------------------------------------------------------------------------------
+
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/hacs/integration)
 [![spotcast](https://img.shields.io/github/release/fondberg/spotcast.svg?1)](https://github.com/fondberg/spotcast)
 ![Maintenance](https://img.shields.io/maintenance/yes/2024.svg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spotcast"
-version = "6.0.0-a16"
+version = "6.0.0-a17"
 description = "Home Assistant custom component to start Spotify playback on an idle Chromecast or a Spotify Connect device. Meaning you can target automation for chromecast as well as connect devices."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/test/test_async_setup_entry.py
+++ b/test/test_async_setup_entry.py
@@ -11,6 +11,9 @@ from custom_components.spotcast import (
     ConfigEntryAuthFailed,
     InternalServerError,
     ConfigEntryNotReady,
+    DOMAIN,
+    MOVED_ISSUE_ID,
+    MOVED_LEARN_MORE_URL,
 )
 from custom_components.spotcast.spotify import SpotifyAccount
 
@@ -19,6 +22,7 @@ TEST_MODULE = "custom_components.spotcast"
 
 class TestEntryRegistration(IsolatedAsyncioTestCase):
 
+    @patch(f"{TEST_MODULE}.ir")
     @patch(f"{TEST_MODULE}.async_cleanup_entities")
     @patch(f"{TEST_MODULE}.async_setup_websocket")
     @patch.object(SpotifyAccount, "async_from_config_entry")
@@ -27,6 +31,7 @@ class TestEntryRegistration(IsolatedAsyncioTestCase):
         mock_account: AsyncMock,
         mock_websocket: AsyncMock,
         mock_cleanup: AsyncMock,
+        mock_ir: MagicMock,
     ):
 
         mock_account.return_value = MagicMock(spec=SpotifyAccount)
@@ -79,6 +84,7 @@ class TestEntryRegistration(IsolatedAsyncioTestCase):
 
 class TestDefaultOptionsSet(IsolatedAsyncioTestCase):
 
+    @patch(f"{TEST_MODULE}.ir")
     @patch(f"{TEST_MODULE}.async_cleanup_entities")
     @patch(f"{TEST_MODULE}.async_setup_websocket")
     @patch.object(SpotifyAccount, "async_from_config_entry")
@@ -87,6 +93,7 @@ class TestDefaultOptionsSet(IsolatedAsyncioTestCase):
         mock_account: MagicMock,
         mock_websocket: AsyncMock,
         mock_cleanup: AsyncMock,
+        mock_ir: MagicMock,
     ):
 
         mock_account.return_value = MagicMock(spec=SpotifyAccount)
@@ -135,8 +142,13 @@ class TestDefaultOptionsSet(IsolatedAsyncioTestCase):
 
 class TestTokensErrorAtRefresh(IsolatedAsyncioTestCase):
 
+    @patch(f"{TEST_MODULE}.ir")
     @patch.object(SpotifyAccount, "async_from_config_entry")
-    async def test_token_error_raised(self, mock_account: AsyncMock):
+    async def test_token_error_raised(
+        self,
+        mock_account: AsyncMock,
+        mock_ir: MagicMock,
+    ):
 
         mock_account.return_value = MagicMock(spec=SpotifyAccount)
 
@@ -169,10 +181,89 @@ class TestTokensErrorAtRefresh(IsolatedAsyncioTestCase):
             )
 
 
+class TestMovedIssueCreated(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.ir")
+    @patch(f"{TEST_MODULE}.async_cleanup_entities")
+    @patch(f"{TEST_MODULE}.async_setup_websocket")
+    @patch.object(SpotifyAccount, "async_from_config_entry")
+    async def asyncSetUp(
+        self,
+        mock_account: AsyncMock,
+        mock_websocket: AsyncMock,
+        mock_cleanup: AsyncMock,
+        mock_ir: MagicMock,
+    ):
+
+        mock_account.return_value = MagicMock(spec=SpotifyAccount)
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "entry": MagicMock(spec=ConfigEntry),
+            "forward_entry": AsyncMock(),
+            "ir": mock_ir,
+            "cleanup": mock_cleanup,
+        }
+
+        self.mocks["hass"].data = {}
+        self.mocks["entry"].entry_id = "foo"
+        self.mocks["entry"].options = {"is_default": True}
+        self.mocks["account"] = mock_account.return_value
+        self.mocks["account"].is_default = True
+        self.mocks["hass"].config_entries\
+            .async_forward_entry_setups = self.mocks["forward_entry"]
+        self.mocks["hass"].services = MagicMock()
+        self.mocks["cleanup"].return_value = 0
+
+        await async_setup_entry(self.mocks["hass"], self.mocks["entry"])
+
+    def test_moved_issue_created(self):
+        self.mocks["ir"].async_create_issue.assert_called_once_with(
+            self.mocks["hass"],
+            DOMAIN,
+            MOVED_ISSUE_ID,
+            is_fixable=False,
+            severity=self.mocks["ir"].IssueSeverity.WARNING,
+            translation_key=MOVED_ISSUE_ID,
+            learn_more_url=MOVED_LEARN_MORE_URL,
+        )
+
+
+class TestMovedIssueCreatedBeforeAuthFailure(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.ir")
+    @patch.object(SpotifyAccount, "async_from_config_entry")
+    async def test_issue_created_even_when_auth_fails(
+        self,
+        mock_account: AsyncMock,
+        mock_ir: MagicMock,
+    ):
+
+        mock_account.side_effect = TokenRefreshError
+
+        hass = MagicMock(spec=HomeAssistant)
+        hass.data = {}
+        entry = MagicMock(spec=ConfigEntry)
+        entry.entry_id = "foo"
+        entry.options = {}
+
+        with self.assertRaises(ConfigEntryAuthFailed):
+            await async_setup_entry(hass, entry)
+
+        # The migration notice must reach abandoned installs that can no
+        # longer authenticate, so it is created before token validation.
+        mock_ir.async_create_issue.assert_called_once()
+
+
 class TestGatewayError(IsolatedAsyncioTestCase):
 
+    @patch(f"{TEST_MODULE}.ir")
     @patch.object(SpotifyAccount, "async_from_config_entry")
-    async def test_token_error_raised(self, mock_account: AsyncMock):
+    async def test_token_error_raised(
+        self,
+        mock_account: AsyncMock,
+        mock_ir: MagicMock,
+    ):
 
         mock_account.return_value = MagicMock(spec=SpotifyAccount)
 
@@ -207,8 +298,13 @@ class TestGatewayError(IsolatedAsyncioTestCase):
 
 class TestTokensErrorAtAccountBuild(IsolatedAsyncioTestCase):
 
+    @patch(f"{TEST_MODULE}.ir")
     @patch.object(SpotifyAccount, "async_from_config_entry")
-    async def test_token_error_raised(self, mock_account: AsyncMock):
+    async def test_token_error_raised(
+        self,
+        mock_account: AsyncMock,
+        mock_ir: MagicMock,
+    ):
 
         mock_account.side_effect = TokenRefreshError
 


### PR DESCRIPTION
## Summary

Spotcast has moved to [Mincka/spotcast](https://github.com/Mincka/spotcast). This adds a one-time in-app migration notice for existing users still on this legacy build and bumps the version to `v6.0.0-a17`. No functional changes.

- Creates a Home Assistant **Repairs** issue on setup (`spotcast_moved`, non-fixable, warning severity) with a **Learn more** link to the migration guide.
- Created early in `async_setup_entry`, before token validation, so it still appears on installs that can no longer authenticate. The issue registry remembers the dismissed state, so it is safe to create on every setup.
- Adds `issues.spotcast_moved` strings (en + fr) and bumps the version across `manifest.json`, `__init__.py`, `pyproject.toml`, and `.bumpversion.cfg`.

Verified on Home Assistant 2026.7.3: the integration loads with no import or setup errors and the repair renders correctly (title, description, Learn more). Existing unit tests updated; full suite green.

As discussed over email. A companion PR adds the same notice to the v4 line, and the README pointer is fondberg#619.

---

## Suggested release notes (copy-paste if useful)

**Release: `v6.0.0-a17`** &nbsp;&middot;&nbsp; tag: `v6.0.0-a17` &nbsp;&middot;&nbsp; target: `dev` &nbsp;&middot;&nbsp; mark as pre-release

> ### Spotcast has moved to Mincka/spotcast
>
> This repository is abandoned and no longer maintained. This release adds **only** an in-app migration notice and has no functional changes, so there is no need to install it. You can switch directly instead.
>
> Spotcast now lives at **https://github.com/Mincka/spotcast**, actively maintained, carrying the full v6 release line. Moving over is a clean swap on the same major version: your accounts, tokens, entities and automations carry over untouched.
>
> **Migration guide:** https://github.com/Mincka/spotcast#coming-from-the-original-fondbergspotcast
>
> If you do install this update, a Home Assistant repair notice will point you to the same guide.
