### PR TITLE
Add a 'Spotcast has moved' migration notice (v4.0.2)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.0.1
+current_version = 4.0.2
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>.*)(?P<build>\d+))?
 serialize = 

--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
-__version__ = "4.0.1"
+__version__ = "4.0.2"
 
 import collections
 import logging
+import os
 import time
 
 import homeassistant.core as ha_core
-from homeassistant.components import websocket_api
+from homeassistant.components import persistent_notification, websocket_api
 from homeassistant.const import CONF_ENTITY_ID, CONF_OFFSET, CONF_REPEAT
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
@@ -73,6 +74,38 @@ DEBUG = True
 
 _LOGGER = logging.getLogger(__name__)
 
+MOVED_NOTIFICATION_ID = "spotcast_moved"
+MOVED_MARKER = ".spotcast_moved_notified"
+MOVED_MESSAGE = (
+    "Spotcast is now maintained at https://github.com/Mincka/spotcast . "
+    "This version, installed from the original fondberg/spotcast "
+    "repository, is abandoned and no longer works with Spotify's current "
+    "authentication. See the migration guide: "
+    "https://github.com/Mincka/spotcast"
+    "#coming-from-the-original-fondbergspotcast"
+)
+
+
+def _notify_spotcast_moved(hass: ha_core.HomeAssistant) -> None:
+    """Show the migration notice once, remembered across restarts."""
+    marker = hass.config.path(MOVED_MARKER)
+
+    if os.path.exists(marker):
+        return
+
+    persistent_notification.create(
+        hass,
+        MOVED_MESSAGE,
+        title="Spotcast has moved",
+        notification_id=MOVED_NOTIFICATION_ID,
+    )
+
+    try:
+        with open(marker, "w", encoding="utf-8"):
+            pass
+    except OSError:
+        _LOGGER.warning("Could not write the Spotcast migration marker")
+
 
 def setup(hass: ha_core.HomeAssistant, config: collections.OrderedDict) -> bool:
     """setup method for integration with Home Assistant
@@ -86,6 +119,13 @@ def setup(hass: ha_core.HomeAssistant, config: collections.OrderedDict) -> bool:
     Returns:
         bool: returns a bollean based on if the setup wroked or not
     """
+
+    # Spotcast has moved to Mincka/spotcast. This v4 build is abandoned
+    # and no longer works with Spotify's current authentication, so show
+    # a one-time notification pointing users to the migration guide. A
+    # marker file makes it fire only once (persistent notifications do
+    # not survive a restart, so recreating on every setup would nag).
+    _notify_spotcast_moved(hass)
 
     # get spotify core integration status
     # if return false, could indicate a bad spotify integration. Race

--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -18,5 +18,5 @@
     "requirements": [
         "spotipy==2.23.0"
     ],
-    "version": "v4.0.1"
+    "version": "v4.0.2"
 }

--- a/info.md
+++ b/info.md
@@ -1,5 +1,13 @@
 # Spotcast
 
+> **Spotcast has moved to [Mincka/spotcast](https://github.com/Mincka/spotcast)**
+>
+> This v4 build is abandoned and no longer works with Spotify's current
+> authentication. This release only adds this migration notice, so there is no
+> need to install it. Switch to the maintained repository instead.
+>
+> **Migration guide:** https://github.com/Mincka/spotcast#coming-from-the-original-fondbergspotcast
+
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs) [![spotcast](https://img.shields.io/github/release/fondberg/spotcast.svg?1)](https://github.com/fondberg/spotcast) ![Maintenance](https://img.shields.io/maintenance/yes/2024.svg)
 
 [![Buy me a coffee](https://img.shields.io/static/v1.svg?label=Buy%20me%20a%20coffee&message=🥨&color=black&logo=buy%20me%20a%20coffee&logoColor=white&labelColor=6f4e37)](https://www.buymeacoffee.com/fondberg)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.0.1
+current_version = 4.0.2
 
 [flake8]
 exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build


### PR DESCRIPTION
## Summary

Spotcast has moved to [Mincka/spotcast](https://github.com/Mincka/spotcast). This adds a one-time in-app migration notice for existing users still on this v4 build and bumps the version to `4.0.2`. No functional changes.

- Shows a one-time `persistent_notification` at the very top of `setup()`, before any credential handling, so it fires even though this build no longer authenticates with Spotify.
- A marker file (`.spotcast_moved_notified`) keeps it to a single showing across restarts.
- Bumps the version across `manifest.json`, `__init__.py`, `setup.cfg`, and `.bumpversion.cfg`.

Verified on Home Assistant 2025.1.4 and 2026.7.3: the integration imports without error and the notification renders (with the migration link) before the expected downstream `spotify integration not found`.

As discussed over email. A companion PR adds the equivalent Repairs notice to the v6 line, and the README pointer is fondberg#619.

---

## Suggested release notes (copy-paste if useful)

**Release: `4.0.2`** &nbsp;&middot;&nbsp; tag: `v4.0.2` &nbsp;&middot;&nbsp; target: `master` &nbsp;&middot;&nbsp; mark as latest

> ### Spotcast has moved to Mincka/spotcast
>
> This v4 build is abandoned and no longer works with Spotify's current authentication. This release adds **only** a one-time migration notification and has no functional fixes, so there is no need to install it. You can switch directly instead.
>
> The v4 line stopped working with Spotify's authentication changes (login loops, reauthentication failures, `400 Bad Request`). The fix is the v6 rewrite, now maintained at **https://github.com/Mincka/spotcast**.
>
> **Migration guide:** https://github.com/Mincka/spotcast#coming-from-the-original-fondbergspotcast
